### PR TITLE
refactor: add Deserialize derive to nodes

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -5,7 +5,7 @@ use crate::display::{
   display_method, display_optional, display_readonly, display_static,
   SliceDisplayer,
 };
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use swc_common::Spanned;
 
 use crate::function::function_to_function_def;

--- a/src/class.rs
+++ b/src/class.rs
@@ -5,7 +5,7 @@ use crate::display::{
   display_method, display_optional, display_readonly, display_static,
   SliceDisplayer,
 };
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use swc_common::Spanned;
 
 use crate::function::function_to_function_def;
@@ -26,7 +26,7 @@ use crate::ParamDef;
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassConstructorDef {
   pub js_doc: Option<String>,
@@ -48,7 +48,7 @@ impl Display for ClassConstructorDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassPropertyDef {
   pub js_doc: Option<String>,
@@ -81,7 +81,7 @@ impl Display for ClassPropertyDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassIndexSignatureDef {
   pub readonly: bool,
@@ -104,7 +104,7 @@ impl Display for ClassIndexSignatureDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassMethodDef {
   pub js_doc: Option<String>,
@@ -140,7 +140,7 @@ impl Display for ClassMethodDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassDef {
   // TODO(bartlomieju): decorators

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::parser::DocParser;
 

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -1,15 +1,15 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 use crate::parser::DocParser;
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EnumMemberDef {
   pub name: String,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EnumDef {
   pub members: Vec<EnumMemberDef>,

--- a/src/function.rs
+++ b/src/function.rs
@@ -6,7 +6,7 @@ use crate::ts_type::TsTypeDef;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
 use crate::ParamDef;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/function.rs
+++ b/src/function.rs
@@ -6,9 +6,9 @@ use crate::ts_type::TsTypeDef;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
 use crate::ParamDef;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FunctionDef {
   pub params: Vec<ParamDef>,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::colors;
 use crate::display::{display_optional, display_readonly, SliceDisplayer};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::params::ts_fn_param_to_param_def;
 use crate::parser::DocParser;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::colors;
 use crate::display::{display_optional, display_readonly, SliceDisplayer};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 use crate::params::ts_fn_param_to_param_def;
 use crate::parser::DocParser;
@@ -14,7 +14,7 @@ use crate::ParamDef;
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceMethodDef {
   pub name: String,
@@ -42,7 +42,7 @@ impl Display for InterfaceMethodDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfacePropertyDef {
   pub name: String,
@@ -70,7 +70,7 @@ impl Display for InterfacePropertyDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceIndexSignatureDef {
   pub readonly: bool,
@@ -93,7 +93,7 @@ impl Display for InterfaceIndexSignatureDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceCallSignatureDef {
   pub location: Location,
@@ -103,7 +103,7 @@ pub struct InterfaceCallSignatureDef {
   pub type_params: Vec<TsTypeParamDef>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceDef {
   pub extends: Vec<TsTypeDef>,

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,11 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 use crate::parser::DocParser;
 use crate::DocNode;
 use crate::DocNodeKind;
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NamespaceDef {
   pub elements: Vec<DocNode>,
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::parser::DocParser;
 use crate::DocNode;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum DocNodeKind {
   Function,
@@ -14,7 +14,7 @@ pub enum DocNodeKind {
   Import,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Location {
   pub filename: String,
   pub line: usize,
@@ -39,7 +39,7 @@ impl Into<Location> for swc_common::Loc {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ReexportKind {
   /// export * from "./path/to/module.js";
@@ -54,28 +54,28 @@ pub enum ReexportKind {
   Named(String, Option<String>),
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Reexport {
   pub kind: ReexportKind,
   pub src: String,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ModuleDoc {
   pub definitions: Vec<DocNode>,
   pub reexports: Vec<Reexport>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportDef {
   pub src: String,
   pub imported: Option<String>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DocNode {
   pub kind: DocNodeKind,

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,12 +1,12 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::display::{display_optional, SliceDisplayer};
 use crate::ts_type::{ts_type_ann_to_def, TsTypeDef};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_common::SourceMap;
 use swc_ecmascript::ast::{ObjectPatProp, Pat, TsFnParam};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "kind")]
 pub enum ParamDef {
@@ -115,7 +115,7 @@ impl Display for ParamDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "kind")]
 pub enum ObjectPatPropDef {

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,7 +1,7 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::display::{display_optional, SliceDisplayer};
 use crate::ts_type::{ts_type_ann_to_def, TsTypeDef};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_common::SourceMap;
 use swc_ecmascript::ast::{ObjectPatProp, Pat, TsFnParam};

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -3,8 +3,8 @@
 // TODO(ry) This module builds up output by appending to a string. Instead it
 // should either use a formatting trait
 // https://doc.rust-lang.org/std/fmt/index.html#formatting-traits
-// Or perhaps implement a Serializer for serde
-// https://docs.serde.rs/serde/ser/trait.Serializer.html
+// Or perhaps implement a Serialize, Deserializer for serde
+// https://docs.serde.rs/serde/ser/trait.Serialize, Deserializer.html
 
 // TODO(ry) The methods in this module take ownership of the DocNodes, this is
 // unnecessary and can result in unnecessary copying. Instead they should take

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -3,8 +3,8 @@
 // TODO(ry) This module builds up output by appending to a string. Instead it
 // should either use a formatting trait
 // https://doc.rust-lang.org/std/fmt/index.html#formatting-traits
-// Or perhaps implement a Serialize, Deserializer for serde
-// https://docs.serde.rs/serde/ser/trait.Serialize, Deserializer.html
+// Or perhaps implement a Serializer for serde
+// https://docs.serde.rs/serde/ser/trait.Serializer.html
 
 // TODO(ry) The methods in this module take ownership of the DocNodes, this is
 // unnecessary and can result in unnecessary copying. Instead they should take

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -6,7 +6,7 @@ use crate::params::ts_fn_param_to_param_def;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
 use crate::ParamDef;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_ecmascript::ast::{
   TsArrayType, TsConditionalType, TsExprWithTypeArgs, TsFnOrConstructorType,
@@ -597,14 +597,14 @@ impl Into<TsTypeDef> for &TsType {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypeRefDef {
   pub type_params: Option<Vec<TsTypeDef>>,
   pub type_name: String,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum LiteralDefKind {
   Number,
@@ -613,7 +613,7 @@ pub enum LiteralDefKind {
   BigInt,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LiteralDef {
   pub kind: LiteralDefKind,
@@ -628,14 +628,14 @@ pub struct LiteralDef {
   pub boolean: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypeOperatorDef {
   pub operator: String,
   pub ts_type: TsTypeDef,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsFnOrConstructorDef {
   pub constructor: bool,
@@ -644,7 +644,7 @@ pub struct TsFnOrConstructorDef {
   pub type_params: Vec<TsTypeParamDef>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsConditionalDef {
   pub check_type: Box<TsTypeDef>,
@@ -653,7 +653,7 @@ pub struct TsConditionalDef {
   pub false_type: Box<TsTypeDef>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsIndexedAccessDef {
   pub readonly: bool,
@@ -661,7 +661,7 @@ pub struct TsIndexedAccessDef {
   pub index_type: Box<TsTypeDef>,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LiteralMethodDef {
   pub name: String,
@@ -685,7 +685,7 @@ impl Display for LiteralMethodDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LiteralPropertyDef {
   pub name: String,
@@ -705,7 +705,7 @@ impl Display for LiteralPropertyDef {
     Ok(())
   }
 }
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LiteralCallSignatureDef {
   pub params: Vec<ParamDef>,
@@ -723,7 +723,7 @@ impl Display for LiteralCallSignatureDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LiteralIndexSignatureDef {
   pub readonly: bool,
@@ -746,7 +746,7 @@ impl Display for LiteralIndexSignatureDef {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypeLiteralDef {
   pub methods: Vec<LiteralMethodDef>,
@@ -755,7 +755,7 @@ pub struct TsTypeLiteralDef {
   pub index_signatures: Vec<LiteralIndexSignatureDef>,
 }
 
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum TsTypeDefKind {
   Keyword,
@@ -777,7 +777,7 @@ pub enum TsTypeDefKind {
   TypeLiteral,
 }
 
-#[derive(Debug, Default, Serialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypeDef {
   pub repr: String,

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -6,7 +6,7 @@ use crate::params::ts_fn_param_to_param_def;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
 use crate::ParamDef;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_ecmascript::ast::{
   TsArrayType, TsConditionalType, TsExprWithTypeArgs, TsFnOrConstructorType,

--- a/src/ts_type_param.rs
+++ b/src/ts_type_param.rs
@@ -1,11 +1,11 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::ts_type::TsTypeDef;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_ecmascript::ast::TsTypeParam;
 use swc_ecmascript::ast::TsTypeParamDecl;
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypeParamDef {
   pub name: String,

--- a/src/ts_type_param.rs
+++ b/src/ts_type_param.rs
@@ -1,6 +1,6 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
 use crate::ts_type::TsTypeDef;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use swc_ecmascript::ast::TsTypeParam;
 use swc_ecmascript::ast::TsTypeParamDecl;

--- a/src/type_alias.rs
+++ b/src/type_alias.rs
@@ -3,7 +3,7 @@ use crate::parser::DocParser;
 use crate::ts_type::TsTypeDef;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/type_alias.rs
+++ b/src/type_alias.rs
@@ -3,9 +3,9 @@ use crate::parser::DocParser;
 use crate::ts_type::TsTypeDef;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeAliasDef {
   pub ts_type: TsTypeDef,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,10 +1,10 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
 use crate::ts_type::ts_type_ann_to_def;
 use crate::ts_type::TsTypeDef;
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VariableDef {
   pub ts_type: Option<TsTypeDef>,

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1,5 +1,5 @@
 // Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::ts_type::ts_type_ann_to_def;
 use crate::ts_type::TsTypeDef;


### PR DESCRIPTION
When using `deno_doc` as a crate, it is useful to support deserialize, such as deserializing the previously generated JSON data and formatting it through `DocPrinter`