### PR TITLE
chore: make colors public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate lazy_static;
 extern crate serde_json;
 
 pub mod class;
-mod colors;
+pub mod colors;
 mod display;
 pub mod r#enum;
 pub mod function;


### PR DESCRIPTION
Finally we will move `printer` back into `deno/cli`, so it is necessary to be able to enable & disable color externally.

(It is annoying to format the interface property alone and cannot carry colors