### PR TITLE
Use GITHUB_ENV instead of set-env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Environment
         run: |
-          echo ::set-env name=GH_ACTIONS::1
-          echo ::set-env name=RUST_BACKTRACE::full
+          echo "GH_ACTIONS=1" >> ${GITHUB_ENV}
+          echo "RUST_BACKTRACE=full" >> ${GITHUB_ENV}
 
       - name: Format
         if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

> Action and workflow authors who are setting environment variables via stdout should update any usage of the set-env and add-path workflow commands to use the new environment files.