### PR TITLE
chore: remove serde_derive from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,6 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "swc_common",
  "swc_ecmascript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ name = "ddoc"
 futures = "0.3.5"
 lazy_static = "1.4.0"
 serde = { version = "1.0.115", features = ["derive"] }
-serde_derive = "1.0.115"
 serde_json = { version = "1.0.57", features = [ "preserve_order" ] }
 swc_common = "=0.10.5"
 swc_ecmascript = { version = "=0.13.3", features = ["parser"] }


### PR DESCRIPTION
`serde_derive` is listed in dependencies, but it is not used at all. Instead we are using `serde::{Serialize, Deserialize}` from `serde` (not `serde_derive`).
So in this PR, I removed `serde_derive` from dependencies.