### PR TITLE
fix: only include declarations in docs if the file is ambient

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -595,14 +595,19 @@ impl DocParser {
   ) -> Vec<DocNode> {
     let mut unexported_doc_map: HashMap<String, DocNode> = HashMap::new();
     let mut doc_entries: Vec<DocNode> = vec![];
+    let mut ambient_entries: Vec<DocNode> = vec![];
+
+    let mut is_ambient = true;
 
     for node in module_body.iter() {
       if let swc_ecmascript::ast::ModuleItem::Stmt(stmt) = node {
         if let Stmt::Decl(decl) = stmt {
           if let Some(doc_node) = self.get_doc_node_for_decl(decl) {
             let is_declared = self.get_declare_for_decl(decl);
-            if is_declared || self.private {
+            if self.private {
               doc_entries.push(doc_node);
+            } else if is_declared {
+              ambient_entries.push(doc_node)
             } else {
               unexported_doc_map.insert(doc_node.name.clone(), doc_node);
             }
@@ -613,6 +618,9 @@ impl DocParser {
 
     for node in module_body.iter() {
       if let swc_ecmascript::ast::ModuleItem::ModuleDecl(module_decl) = node {
+        // If it has imports/exports, it isn't ambient.
+        is_ambient = false;
+
         doc_entries.extend(self.get_doc_nodes_for_module_exports(module_decl));
 
         if let ModuleDecl::ExportNamed(export_named) = module_decl {
@@ -635,6 +643,10 @@ impl DocParser {
           }
         }
       }
+    }
+
+    if is_ambient {
+      doc_entries.extend(ambient_entries);
     }
 
     doc_entries

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1640,7 +1640,7 @@ export { hello, say, foo as bar };
   ]
     );
 
-  json_test!(non_implemented_renamed_exports_declared_earlier, 
+  json_test!(non_implemented_renamed_exports_declared_earlier,
     r#"
 declare function foo(): void;
 export { foo as bar };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1970,10 +1970,41 @@ export { hello, say, foo as bar };
   ]
     );
 
-  json_test!(non_implemented_renamed_exports_declared_earlier,
+  // TODO(#57): This will pass once both #59 and #60 are merged
+  // json_test!(non_implemented_renamed_exports_declared_earlier,
+  //   r#"
+  // declare function foo(): void;
+  // export { foo as bar };
+  //   "#;
+  //   [
+  //     {
+  //       "kind": "function",
+  //       "name": "bar",
+  //       "location": {
+  //         "filename": "test.ts",
+  //         "line": 2,
+  //         "col": 10
+  //       },
+  //       "jsDoc": null,
+  //       "functionDef": {
+  //         "params": [],
+  //         "returnType": {
+  //           "repr": "void",
+  //           "kind": "keyword",
+  //           "keyword": "void"
+  //         },
+  //         "isAsync": false,
+  //         "isGenerator": false,
+  //         "typeParams": []
+  //       }
+  //     }
+  //   ]
+  // );
+
+  json_test!(no_ambient_in_module,
     r#"
-declare function foo(): void;
-export { foo as bar };
+declare function foo(): number;
+export function bar() {};
     "#;
     [
       {
@@ -1981,17 +2012,13 @@ export { foo as bar };
         "name": "bar",
         "location": {
           "filename": "test.ts",
-          "line": 2,
-          "col": 8
+          "line": 3,
+          "col": 0
         },
         "jsDoc": null,
         "functionDef": {
           "params": [],
-          "returnType": {
-            "repr": "void",
-            "kind": "keyword",
-            "keyword": "void"
-          },
+          "returnType": null,
           "isAsync": false,
           "isGenerator": false,
           "typeParams": []

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1640,6 +1640,36 @@ export { hello, say, foo as bar };
   ]
     );
 
+  json_test!(non_implemented_renamed_exports_declared_earlier, 
+    r#"
+declare function foo(): void;
+export { foo as bar };
+    "#;
+    [
+      {
+        "kind": "function",
+        "name": "bar",
+        "location": {
+          "filename": "test.ts",
+          "line": 2,
+          "col": 8
+        },
+        "jsDoc": null,
+        "functionDef": {
+          "params": [],
+          "returnType": {
+            "repr": "void",
+            "kind": "keyword",
+            "keyword": "void"
+          },
+          "isAsync": false,
+          "isGenerator": false,
+          "typeParams": []
+        }
+      }
+    ]
+  );
+
   json_test!(optional_return_type,
     r#"
   export function foo(a: number) {


### PR DESCRIPTION
Previously, the `declare` keyword was taken to indicate a global variable and shown in the documentation. However, that is only be the case for ambient declarations - in modules, this just indicates a private value.

Partially fixes #57