### PR TITLE
fix: support default exports for statements declared earlier

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -663,7 +663,7 @@ impl DocParser {
               }
             }
             ModuleDecl::ExportDefaultExpr(export_expr) => {
-              if let Expr::Ident(ident) = &*export_expr.expr {
+              if let Expr::Ident(ident) = export_expr.expr.as_ref() {
                 if let Some(doc_node) = symbols.get(&ident.sym.to_string()) {
                   doc_entries.push(DocNode {
                     name: String::from("default"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1640,6 +1640,36 @@ export { hello, say, foo as bar };
   ]
     );
 
+  json_test!(default_exports_declared_earlier,
+    r#"
+function foo(): void {}
+export default foo;
+    "#;
+    [
+      {
+        "kind": "function",
+        "name": "default",
+        "location": {
+          "filename": "test.ts",
+          "line": 2,
+          "col": 0
+        },
+        "jsDoc": null,
+        "functionDef": {
+          "params": [],
+          "returnType": {
+            "repr": "void",
+            "kind": "keyword",
+            "keyword": "void"
+          },
+          "isAsync": false,
+          "isGenerator": false,
+          "typeParams": []
+        }
+      }
+    ]
+  );
+
   json_test!(optional_return_type,
     r#"
   export function foo(a: number) {


### PR DESCRIPTION
fixes #62

Note: this includes the changes from #59, since this kind of needs those changes (at least not to have merge conflicts).