### PR TITLE
feat: Add support for filtering class and interface fields

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -21,6 +21,8 @@ use crate::ts_type::{
 };
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
+use crate::variable::VariableDef;
+use crate::DocNode;
 use crate::Location;
 use crate::ParamDef;
 
@@ -60,6 +62,20 @@ pub struct ClassPropertyDef {
   pub is_static: bool,
   pub name: String,
   pub location: Location,
+}
+
+impl Into<DocNode> for ClassPropertyDef {
+  fn into(self) -> DocNode {
+    DocNode::variable(
+      self.name,
+      self.location,
+      self.js_doc,
+      VariableDef {
+        ts_type: self.ts_type,
+        kind: swc_ecmascript::ast::VarDeclKind::Const,
+      },
+    )
+  }
 }
 
 impl Display for ClassPropertyDef {
@@ -116,6 +132,12 @@ pub struct ClassMethodDef {
   pub kind: swc_ecmascript::ast::MethodKind,
   pub function_def: FunctionDef,
   pub location: Location,
+}
+
+impl Into<DocNode> for ClassMethodDef {
+  fn into(self) -> DocNode {
+    DocNode::function(self.name, self.location, self.js_doc, self.function_def)
+  }
 }
 
 impl Display for ClassMethodDef {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -3,12 +3,15 @@ use crate::colors;
 use crate::display::{display_optional, display_readonly, SliceDisplayer};
 use serde::{Deserialize, Serialize};
 
+use crate::function::FunctionDef;
 use crate::params::ts_fn_param_to_param_def;
 use crate::parser::DocParser;
 use crate::ts_type::ts_type_ann_to_def;
 use crate::ts_type::TsTypeDef;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
+use crate::variable::VariableDef;
+use crate::DocNode;
 use crate::Location;
 use crate::ParamDef;
 
@@ -24,6 +27,23 @@ pub struct InterfaceMethodDef {
   pub params: Vec<ParamDef>,
   pub return_type: Option<TsTypeDef>,
   pub type_params: Vec<TsTypeParamDef>,
+}
+
+impl Into<DocNode> for InterfaceMethodDef {
+  fn into(self) -> DocNode {
+    DocNode::function(
+      self.name,
+      self.location,
+      self.js_doc,
+      FunctionDef {
+        params: self.params,
+        return_type: self.return_type,
+        is_async: false,
+        is_generator: false,
+        type_params: self.type_params,
+      },
+    )
+  }
 }
 
 impl Display for InterfaceMethodDef {
@@ -53,6 +73,20 @@ pub struct InterfacePropertyDef {
   pub optional: bool,
   pub ts_type: Option<TsTypeDef>,
   pub type_params: Vec<TsTypeParamDef>,
+}
+
+impl Into<DocNode> for InterfacePropertyDef {
+  fn into(self) -> DocNode {
+    DocNode::variable(
+      self.name,
+      self.location,
+      self.js_doc,
+      VariableDef {
+        ts_type: self.ts_type,
+        kind: swc_ecmascript::ast::VarDeclKind::Const,
+      },
+    )
+  }
 }
 
 impl Display for InterfacePropertyDef {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,11 @@ pub fn find_nodes_by_name_recursively(
   match leftover {
     Some(leftover) => {
       for node in doc_nodes {
-        let children = find_children_by_name(node, leftover.to_string());
-        found.extend(children);
+        let children = get_children_of_node(node);
+        found.extend(find_nodes_by_name_recursively(
+          children,
+          leftover.to_string(),
+        ));
       }
       found
     }
@@ -76,13 +79,34 @@ fn find_nodes_by_name(doc_nodes: Vec<DocNode>, name: String) -> Vec<DocNode> {
   found
 }
 
-fn find_children_by_name(node: DocNode, name: String) -> Vec<DocNode> {
+fn get_children_of_node(node: DocNode) -> Vec<DocNode> {
   match node.kind {
     DocNodeKind::Namespace => {
       let namespace_def = node.namespace_def.unwrap();
-      find_nodes_by_name_recursively(namespace_def.elements, name)
+      namespace_def.elements
     }
-    // TODO(#4516) handle class, interface etc...
+    DocNodeKind::Interface => {
+      let interface_def = node.interface_def.unwrap();
+      let mut doc_nodes: Vec<DocNode> = vec![];
+      for method in interface_def.methods {
+        doc_nodes.push(method.into());
+      }
+      for property in interface_def.properties {
+        doc_nodes.push(property.into());
+      }
+      doc_nodes
+    }
+    DocNodeKind::Class => {
+      let class_def = node.class_def.unwrap();
+      let mut doc_nodes: Vec<DocNode> = vec![];
+      for method in class_def.methods {
+        doc_nodes.push(method.into());
+      }
+      for property in class_def.properties {
+        doc_nodes.push(property.into());
+      }
+      doc_nodes
+    }
     _ => vec![],
   }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -475,7 +475,7 @@ export namespace Deno {
   assert_eq!(found[0].name, "output".to_string());
   assert_eq!(found[0].kind, DocNodeKind::Function);
 
-  // Not found
+  // No match
   let found =
     find_nodes_by_name_recursively(entries.clone(), "Deno.test.a".to_string());
   assert_eq!(found.len(), 0);


### PR DESCRIPTION
This PR implements `detail output for class fields` listed at the issue #4:

**detail output for interface fields:**

```shell
$ ./target/debug/examples/ddoc ../deno/std/encoding/csv.ts ParseOptions.columns
Defined in file:///home/uki00a/ghq/github.com/uki00a/deno/std/encoding/csv.ts:363:2

const columns: string[] | ColumnOptions[]
  If you provide `string[]` or `ColumnOptions[]`, those names will be used for header definition.
```

**detail output for class fields:**

```shell
$ ./target/debug/examples/ddoc ../deno/std/io/bufio.ts BufReader.read
Defined in file:///home/uki00a/ghq/github.com/uki00a/deno/std/io/bufio.ts:124:2

async function read(p: Uint8Array): Promise<number | null>
  reads data into p.
  It returns the number of bytes read into p.
  The bytes are taken from at most one Read on the underlying Reader,
  hence n may be less than len(p).
  To read exactly len(p) bytes, use io.ReadFull(b, p).
```