### PR TITLE
chore: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true


### PR DESCRIPTION
This PR adds `.editorconfig` based on [the one in denoland/deno](https://github.com/denoland/deno/blob/master/.editorconfig).