### PR TITLE
feat: handle user-defined type guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ast_node"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,13 +104,23 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -146,6 +165,7 @@ dependencies = [
  "clap",
  "futures",
  "lazy_static",
+ "pretty_assertions",
  "regex",
  "serde",
  "serde_json",
@@ -155,6 +175,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "either"
@@ -511,6 +537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +638,18 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "proc-macro-hack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ regex = "=1.4.3"
 clap = "2.33.3"
 tokio = { version = "1.5.0", features = ["full"] }
 url = "2.2.1"
+pretty_assertions = "0.7.2"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2541,7 +2541,7 @@ export { foo };
     ]
   );
 
-  json_test!(ts_user_defined_type_guard_1,
+  json_test!(ts_type_predicate_1,
     r#"
 export function foo(bar: A | B): bar is A {}
     "#,
@@ -2591,7 +2591,10 @@ export function foo(bar: A | B): bar is A {}
             "kind": "typePredicate",
             "typePredicate": {
               "asserts": false,
-              "param": "bar",
+              "param": {
+                "type": "identifier",
+                "name": "bar"
+              },
               "type": {
                 "repr": "A",
                 "kind": "typeRef",
@@ -2600,6 +2603,197 @@ export function foo(bar: A | B): bar is A {}
                   "typeName": "A"
                 }
               }
+            }
+          },
+          "isAsync": false,
+          "isGenerator": false,
+          "typeParams": []
+        }
+      }
+    ]
+  );
+
+  json_test!(ts_type_predicate_2,
+    r#"
+export function foo(bar: A | B): asserts bar is B {}
+    "#,
+    private;
+    [
+      {
+        "kind": "function",
+        "name": "foo",
+        "location": {
+          "filename": "test.ts",
+          "line": 2,
+          "col": 0
+        },
+        "jsDoc": null,
+        "functionDef": {
+          "params": [
+            {
+              "kind": "identifier",
+              "name": "bar",
+              "optional": false,
+              "tsType": {
+                "repr": "",
+                "kind": "union",
+                "union": [
+                  {
+                    "repr": "A",
+                    "kind": "typeRef",
+                    "typeRef": {
+                      "typeParams": null,
+                      "typeName": "A"
+                    }
+                  },
+                  {
+                    "repr": "B",
+                    "kind": "typeRef",
+                    "typeRef": {
+                      "typeParams": null,
+                      "typeName": "B"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "returnType": {
+            "repr": "asserts bar is B",
+            "kind": "typePredicate",
+            "typePredicate": {
+              "asserts": true,
+              "param": {
+                "type": "identifier",
+                "name": "bar"
+              },
+              "type": {
+                "repr": "B",
+                "kind": "typeRef",
+                "typeRef": {
+                  "typeParams": null,
+                  "typeName": "B"
+                }
+              }
+            }
+          },
+          "isAsync": false,
+          "isGenerator": false,
+          "typeParams": []
+        }
+      }
+    ]
+  );
+
+  json_test!(ts_type_predicate_3,
+    r#"
+export class C {
+  isSomething(): this is Something {}
+}
+    "#,
+    private;
+    [
+      {
+        "kind": "class",
+        "name": "C",
+        "location": {
+          "filename": "test.ts",
+          "line": 2,
+          "col": 0
+        },
+        "jsDoc": null,
+        "classDef": {
+          "isAbstract": false,
+          "constructors": [],
+          "properties": [],
+          "indexSignatures": [],
+          "methods": [
+            {
+              "jsDoc": null,
+              "accessibility": null,
+              "optional": false,
+              "isAbstract": false,
+              "isStatic": false,
+              "name": "isSomething",
+              "kind": "method",
+              "functionDef": {
+                "params": [],
+                "returnType": {
+                  "repr": "this is Something",
+                  "kind": "typePredicate",
+                  "typePredicate": {
+                    "asserts": false,
+                    "param": {
+                      "type": "this"
+                    },
+                    "type": {
+                      "repr": "Something",
+                      "kind": "typeRef",
+                      "typeRef": {
+                        "typeParams": null,
+                        "typeName": "Something",
+                      },
+                    },
+                  },
+                },
+                "isAsync": false,
+                "isGenerator": false,
+                "typeParams": [],
+              },
+              "location": {
+                "filename": "test.ts",
+                "line": 3,
+                "col": 2
+              }
+            }
+          ],
+          "extends": null,
+          "implements": [],
+          "typeParams": [],
+          "superTypeParams": []
+        }
+      }
+    ]
+  );
+
+  json_test!(ts_type_assertion,
+    r#"
+export function foo(bar: any): asserts bar {}
+    "#,
+    private;
+    [
+      {
+        "kind": "function",
+        "name": "foo",
+        "location": {
+          "filename": "test.ts",
+          "line": 2,
+          "col": 0
+        },
+        "jsDoc": null,
+        "functionDef": {
+          "params": [
+            {
+              "kind": "identifier",
+              "name": "bar",
+              "optional": false,
+              "tsType": {
+                "repr": "any",
+                "kind": "keyword",
+                "keyword": "any"
+              }
+            }
+          ],
+          "returnType": {
+            "repr": "asserts bar",
+            "kind": "typePredicate",
+            "typePredicate": {
+              "asserts": true,
+              "param": {
+                "type": "identifier",
+                "name": "bar"
+              },
+              "type": null,
             }
           },
           "isAsync": false,
@@ -3142,10 +3336,16 @@ export function assertIsDefined<T>(val4: T): asserts val4 is NonNullable<T> {
     );
   }
 }
+export class C {
+  isSomething(): this is Something {
+    return this instanceof Something;
+  }
+}
     "#;
     "val1 is A",
     "asserts val2 is string",
     "asserts val3",
-    "asserts val4 is NonNullable<T>"
+    "asserts val4 is NonNullable<T>",
+    "this is Something"
   );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,7 @@ use crate::printer::DocPrinter;
 use crate::swc_util;
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
+use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::collections::HashMap;
 use swc_ecmascript::parser::Syntax;
@@ -130,7 +131,7 @@ macro_rules! json_test {
     doc_test!($name, $source, $private; |entries, _doc| {
       let actual = serde_json::to_value(&entries).unwrap();
       let expected_json = json!($json);
-      assert_eq!(actual, expected_json);
+      pretty_assertions::assert_eq!(actual, expected_json);
     });
   };
 }
@@ -2535,6 +2536,75 @@ export { foo };
             "keyword": "string"
           },
           "kind": "const"
+        }
+      }
+    ]
+  );
+
+  json_test!(ts_user_defined_type_guard_1,
+    r#"
+export function foo(bar: A | B): bar is A {}
+    "#,
+    private;
+    [
+      {
+        "kind": "function",
+        "name": "foo",
+        "location": {
+          "filename": "test.ts",
+          "line": 2,
+          "col": 0
+        },
+        "jsDoc": null,
+        "functionDef": {
+          "params": [
+            {
+              "kind": "identifier",
+              "name": "bar",
+              "optional": false,
+              "tsType": {
+                "repr": "",
+                "kind": "union",
+                "union": [
+                  {
+                    "repr": "A",
+                    "kind": "typeRef",
+                    "typeRef": {
+                      "typeParams": null,
+                      "typeName": "A"
+                    }
+                  },
+                  {
+                    "repr": "B",
+                    "kind": "typeRef",
+                    "typeRef": {
+                      "typeParams": null,
+                      "typeName": "B"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "returnType": {
+            "repr": "bar is A",
+            "kind": "typePredicate",
+            "typePredicate": {
+              "asserts": false,
+              "param": "bar",
+              "type": {
+                "repr": "A",
+                "kind": "typeRef",
+                "typeRef": {
+                  "typeParams": null,
+                  "typeName": "A"
+                }
+              }
+            }
+          },
+          "isAsync": false,
+          "isGenerator": false,
+          "typeParams": []
         }
       }
     ]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3058,4 +3058,24 @@ export const sym = Symbol("hello");
     "const bi2: bigint",
     "const sym: symbol"
   );
+
+  contains_test!(
+    ts_user_defined_type_guards,
+    r#"
+export function f1(val1: A | B): val1 is A {}
+export function f2(val2: any): asserts val2 is string {}
+export function f3(val3: any): asserts val3 {}
+export function assertIsDefined<T>(val4: T): asserts val4 is NonNullable<T> {
+  if (val === undefined || val === null) {
+    throw new AssertionError(
+      `Expected 'val' to be defined, but received ${val}`
+    );
+  }
+}
+    "#;
+    "val1 is A",
+    "asserts val2 is string",
+    "asserts val3",
+    "asserts val4 is NonNullable<T>"
+  );
 }

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -830,10 +830,10 @@ pub struct TsTypeDef {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(untagged, rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 pub enum ThisOrIdent {
   This,
-  Ident(String),
+  Identifier { name: String },
 }
 
 impl From<&TsThisTypeOrIdent> for ThisOrIdent {
@@ -841,7 +841,9 @@ impl From<&TsThisTypeOrIdent> for ThisOrIdent {
     use TsThisTypeOrIdent::*;
     match other {
       TsThisType(_) => Self::This,
-      Ident(ident) => Self::Ident(ident.sym.to_string()),
+      Ident(ident) => Self::Identifier {
+        name: ident.sym.to_string(),
+      },
     }
   }
 }
@@ -867,7 +869,7 @@ impl Display for TsTypePredicateDef {
     }
     s.push(match &self.param {
       ThisOrIdent::This => "this".to_string(),
-      ThisOrIdent::Ident(i) => i.clone(),
+      ThisOrIdent::Identifier { name } => name.clone(),
     });
     if let Some(ty) = &self.r#type {
       s.push("is".to_string());
@@ -1261,19 +1263,7 @@ impl Display for TsTypeDef {
       }
       TsTypeDefKind::TypePredicate => {
         let pred = self.type_predicate.as_ref().unwrap();
-        let mut s = Vec::new();
-        if pred.asserts {
-          s.push("asserts".to_string());
-        }
-        s.push(match &pred.param {
-          ThisOrIdent::This => "this".to_string(),
-          ThisOrIdent::Ident(i) => i.clone(),
-        });
-        if let Some(ty) = &pred.r#type {
-          s.push("is".to_string());
-          s.push(ty.to_string());
-        }
-        write!(f, "{}", s.join(" "))
+        write!(f, "{}", pred)
       }
     }
   }

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -214,14 +214,14 @@ impl From<&TsTypePredicate> for TsTypeDef {
     let pred = TsTypePredicateDef {
       asserts: other.asserts,
       param: (&other.param_name).into(),
-      ty: other
+      r#type: other
         .type_ann
         .as_ref()
         .map(|t| Box::new(ts_type_ann_to_def(t))),
     };
     TsTypeDef {
       repr: pred.to_string(),
-      kind: Some(TsTypeDefKind::Predicate),
+      kind: Some(TsTypeDefKind::TypePredicate),
       type_predicate: Some(pred),
       ..Default::default()
     }
@@ -764,7 +764,7 @@ pub enum TsTypeDefKind {
   Conditional,
   IndexedAccess,
   TypeLiteral,
-  Predicate,
+  TypePredicate,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
@@ -849,14 +849,14 @@ impl From<&TsThisTypeOrIdent> for ThisOrIdent {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypePredicateDef {
-  /// Whether the predicate includes `assserts` keyword or not
+  /// Whether the predicate includes `asserts` keyword or not
   pub asserts: bool,
 
-  /// The asserted parameter
+  /// The term of predicate
   pub param: ThisOrIdent,
 
-  /// The type against which the parameter is asserted
-  pub ty: Option<Box<TsTypeDef>>,
+  /// The type against which the parameter is checked
+  pub r#type: Option<Box<TsTypeDef>>,
 }
 
 impl Display for TsTypePredicateDef {
@@ -869,7 +869,7 @@ impl Display for TsTypePredicateDef {
       ThisOrIdent::This => "this".to_string(),
       ThisOrIdent::Ident(i) => i.clone(),
     });
-    if let Some(ty) = &self.ty {
+    if let Some(ty) = &self.r#type {
       s.push("is".to_string());
       s.push(ty.to_string());
     }
@@ -1259,7 +1259,7 @@ impl Display for TsTypeDef {
         let union = self.union.as_ref().unwrap();
         write!(f, "{}", SliceDisplayer::new(union, " | ", false))
       }
-      TsTypeDefKind::Predicate => {
+      TsTypeDefKind::TypePredicate => {
         let pred = self.type_predicate.as_ref().unwrap();
         let mut s = Vec::new();
         if pred.asserts {
@@ -1269,7 +1269,7 @@ impl Display for TsTypeDef {
           ThisOrIdent::This => "this".to_string(),
           ThisOrIdent::Ident(i) => i.clone(),
         });
-        if let Some(ty) = &pred.ty {
+        if let Some(ty) = &pred.r#type {
           s.push("is".to_string());
           s.push(ty.to_string());
         }

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -848,16 +848,21 @@ impl From<&TsThisTypeOrIdent> for ThisOrIdent {
   }
 }
 
+/// ```ts
+/// function foo(param: any): asserts param is SomeType { ... }
+///                           ^^^^^^^ ^^^^^    ^^^^^^^^
+///                           (1)     (2)      (3)
+/// ```
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypePredicateDef {
-  /// Whether the predicate includes `asserts` keyword or not
+  /// (1) Whether the predicate includes `asserts` keyword or not
   pub asserts: bool,
 
-  /// The term of predicate
+  /// (2) The term of predicate
   pub param: ThisOrIdent,
 
-  /// The type against which the parameter is checked
+  /// (3) The type against which the parameter is checked
   pub r#type: Option<Box<TsTypeDef>>,
 }
 


### PR DESCRIPTION
This PR deals with TypeScript user-defined type predicate and assertion, which were unimplemented as reported in #102. Additionally, added `pretty_assertions` crate as a dev-dependency so we can easily spot the difference between expected and actual JSON output.
As far as I understand, to address #102 completely, we need to fix [doc_website](https://github.com/denoland/doc_website) as well. I will work on it later.

#### Demo

```ts
export function f1(val1: A | B): val1 is A {}
export function f2(val2: any): asserts val2 is string {}
export function f3(val3: any): asserts val3 {}
export function assertIsDefined<T>(val4: T): asserts val4 is NonNullable<T> {
  if (val === undefined || val === null) {
    throw new AssertionError(
      `Expected 'val' to be defined, but received ${val}`
    );
  }
}
export class C {
  isSomething(): this is Something {
    return this instanceof Something;
  }
}
```

Running `cargo run --example ddoc foo.ts`, we get:

```
Defined in file:///home/yusuktan/Repos/github.com/magurotuna/deno_doc/foo.ts:4:0

function assertIsDefined<T>(val4: T): asserts val4 is NonNullable<T>

Defined in file:///home/yusuktan/Repos/github.com/magurotuna/deno_doc/foo.ts:1:0

function f1(val1: A | B): val1 is A

Defined in file:///home/yusuktan/Repos/github.com/magurotuna/deno_doc/foo.ts:2:0

function f2(val2: any): asserts val2 is string

Defined in file:///home/yusuktan/Repos/github.com/magurotuna/deno_doc/foo.ts:3:0

function f3(val3: any): asserts val3

Defined in file:///home/yusuktan/Repos/github.com/magurotuna/deno_doc/foo.ts:11:0

class C

  isSomething(): this is Something
```
