### PR TITLE
chore: upgrade Rust to 1.54.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install rust
         uses: hecrj/setup-rust-action@v1.3.4
         with:
-          rust-version: 1.53.0
+          rust-version: 1.54.0
 
       - name: Install clippy and rustfmt
         run: |

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ $ cargo run --example ddoc ../deno/std/http/mod.ts
 
 ## Developing
 
-Make sure to have latest stable version of Rust installed (1.53.0).
+Make sure to have latest stable version of Rust installed (1.54.0).
 
 ```shell
 // check version
 $ rustc --version
-rustc 1.53.0 (53cb7b09b 2021-06-17)
+rustc 1.54.0 (a178d0322 2021-07-26)
 
 // build all targets
 $ cargo build --all-targets

--- a/src/class.rs
+++ b/src/class.rs
@@ -261,7 +261,7 @@ pub fn class_to_class_def(
           Some(&doc_parser.ast_parser.source_map),
         );
         let fn_def =
-          function_to_function_def(&doc_parser, &class_method.function);
+          function_to_function_def(doc_parser, &class_method.function);
         let method_def = ClassMethodDef {
           js_doc: method_js_doc,
           accessibility: class_method.accessibility,

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -36,53 +36,53 @@ fn style(s: &str, colorspec: ColorSpec) -> impl fmt::Display {
 pub fn yellow(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(11)));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn cyan(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(14)));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn red(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Red));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn green(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Green)).set_intense(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn magenta(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Magenta));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn bold(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_bold(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn gray(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(8)));
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn italic_gray(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Ansi256(8))).set_italic(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }
 
 pub fn intense_blue(s: &str) -> impl fmt::Display {
   let mut style_spec = ColorSpec::new();
   style_spec.set_fg(Some(Blue)).set_intense(true);
-  style(&s, style_spec)
+  style(s, style_spec)
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -53,6 +53,6 @@ pub fn get_doc_for_fn_decl(
   fn_decl: &swc_ecmascript::ast::FnDecl,
 ) -> (String, FunctionDef) {
   let name = fn_decl.ident.sym.to_string();
-  let fn_def = function_to_function_def(&doc_parser, &fn_decl.function);
+  let fn_def = function_to_function_def(doc_parser, &fn_decl.function);
   (name, fn_def)
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -96,7 +96,7 @@ impl Display for ParamDef {
         write!(
           f,
           "{{{}}}{}",
-          SliceDisplayer::new(&props, ", ", false),
+          SliceDisplayer::new(props, ", ", false),
           display_optional(*optional)
         )?;
         if let Some(ts_type) = ts_type {
@@ -248,7 +248,7 @@ pub fn pat_to_param_def(
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   match pat {
-    Pat::Ident(ident) => ident_to_param_def(&ident, source_map),
+    Pat::Ident(ident) => ident_to_param_def(ident, source_map),
     Pat::Array(array_pat) => array_pat_to_param_def(array_pat, source_map),
     Pat::Rest(rest_pat) => rest_pat_to_param_def(rest_pat, source_map),
     Pat::Object(object_pat) => object_pat_to_param_def(object_pat, source_map),
@@ -262,7 +262,7 @@ pub fn ts_fn_param_to_param_def(
   source_map: Option<&SourceMap>,
 ) -> ParamDef {
   match ts_fn_param {
-    TsFnParam::Ident(ident) => ident_to_param_def(&ident, source_map),
+    TsFnParam::Ident(ident) => ident_to_param_def(ident, source_map),
     TsFnParam::Array(array_pat) => {
       array_pat_to_param_def(array_pat, source_map)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,7 +131,7 @@ impl DocParser {
     syntax: Syntax,
     source_code: &str,
   ) -> Result<Vec<DocNode>, DocError> {
-    let module_doc = self.parse_module(file_name, syntax, &source_code)?;
+    let module_doc = self.parse_module(file_name, syntax, source_code)?;
     Ok(module_doc.definitions)
   }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -71,7 +71,7 @@ impl<'a> DocPrinter<'a> {
         ))
       )?;
 
-      self.format_signature(w, &node, indent)?;
+      self.format_signature(w, node, indent)?;
 
       let js_doc = &node.js_doc;
       if let Some(js_doc) = js_doc {
@@ -140,7 +140,7 @@ impl<'a> DocPrinter<'a> {
     indent: i64,
   ) -> FmtResult {
     for line in jsdoc.lines() {
-      writeln!(w, "{}{}", Indent(indent), colors::gray(&line))?;
+      writeln!(w, "{}{}", Indent(indent), colors::gray(line))?;
     }
 
     Ok(())
@@ -151,7 +151,7 @@ impl<'a> DocPrinter<'a> {
     for node in &class_def.constructors {
       writeln!(w, "{}{}", Indent(1), node,)?;
       if let Some(js_doc) = &node.js_doc {
-        self.format_jsdoc(w, &js_doc, 2)?;
+        self.format_jsdoc(w, js_doc, 2)?;
       }
     }
     for node in class_def.properties.iter().filter(|node| {
@@ -163,7 +163,7 @@ impl<'a> DocPrinter<'a> {
     }) {
       writeln!(w, "{}{}", Indent(1), node,)?;
       if let Some(js_doc) = &node.js_doc {
-        self.format_jsdoc(w, &js_doc, 2)?;
+        self.format_jsdoc(w, js_doc, 2)?;
       }
     }
     for index_sign_def in &class_def.index_signatures {
@@ -227,7 +227,7 @@ impl<'a> DocPrinter<'a> {
   ) -> FmtResult {
     let elements = &node.namespace_def.as_ref().unwrap().elements;
     for node in elements {
-      self.format_signature(w, &node, 1)?;
+      self.format_signature(w, node, 1)?;
       if let Some(js_doc) = &node.js_doc {
         self.format_jsdoc(w, js_doc, 2)?;
       }

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -1030,7 +1030,7 @@ pub fn infer_simple_ts_type_from_expr(
   match expr {
     Expr::Lit(lit) => {
       // e.g.) const n = 100;
-      infer_ts_type_from_lit(&lit, is_const)
+      infer_ts_type_from_lit(lit, is_const)
     }
     Expr::New(expr) => {
       // e.g.) const d = new Date()
@@ -1194,7 +1194,7 @@ impl Display for TsTypeDef {
       }
       TsTypeDefKind::Intersection => {
         let intersection = self.intersection.as_ref().unwrap();
-        write!(f, "{}", SliceDisplayer::new(&intersection, " & ", false))
+        write!(f, "{}", SliceDisplayer::new(intersection, " & ", false))
       }
       TsTypeDefKind::Keyword => {
         write!(f, "{}", colors::cyan(self.keyword.as_ref().unwrap()))
@@ -1234,7 +1234,7 @@ impl Display for TsTypeDef {
       TsTypeDefKind::This => write!(f, "this"),
       TsTypeDefKind::Tuple => {
         let tuple = self.tuple.as_ref().unwrap();
-        write!(f, "[{}]", SliceDisplayer::new(&tuple, ", ", false))
+        write!(f, "[{}]", SliceDisplayer::new(tuple, ", ", false))
       }
       TsTypeDefKind::TypeLiteral => {
         let type_literal = self.type_literal.as_ref().unwrap();

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -33,7 +33,7 @@ pub fn get_doc_for_var_decl(
   let variable_def = VariableDef {
     ts_type: maybe_ts_type.or_else(|| {
       infer_simple_ts_type_from_var_decl(
-        &var_declarator,
+        var_declarator,
         var_decl.kind == swc_ecmascript::ast::VarDeclKind::Const,
       )
     }),


### PR DESCRIPTION
Upgrades Rust to 1.54.0 and applys clippy's fixes.