### PR TITLE
refactor: migrate to deno_graph and other wasm prep-work

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/rust/.devcontainer/base.Dockerfile
+
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+
+ENV DENO_INSTALL=/deno
+RUN mkdir -p /deno \
+    && curl -fsSL https://deno.land/x/install/install.sh | sh \
+    && chown -R vscode /deno
+
+ENV PATH=${DENO_INSTALL}/bin:${PATH} \
+    DENO_DIR=${DENO_INSTALL}/.cache/deno
+
+RUN rustup target add wasm32-unknown-unknown
+RUN cargo install -f wasm-bindgen-cli
+
+RUN chown -R vscode /usr/local/cargo

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "deno_graph",
+  "name": "deno_doc",
   "build": {
     "dockerfile": "Dockerfile"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "deno_graph",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined"
+  ],
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "lldb.executable": "/usr/bin/lldb",
+    "files.watcherExclude": {
+      "**/target/**": true
+    }
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "matklad.rust-analyzer",
+    "vadimcn.vscode-lldb",
+    "serayuzgur.crates",
+    "mutantdino.resourcemonitor",
+    "tamasfe.even-better-toml",
+    "denoland.vscode-deno"
+  ],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "rustc --version",
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
         run: rustfmt --check src/lib.rs
 
       - name: Build
-        run: cargo build --locked --release --all-targets
+        run: cargo build --locked --release --all-targets --all-features
 
       - name: Test
-        run: cargo test --locked --release --all-targets
+        run: cargo test --locked --release --all-targets --all-features
 
       - name: Lint
-        run: cargo clippy --all-targets --release --locked -- -D clippy::all
+        run: cargo clippy --all-targets --all-features --release --locked -- -D clippy::all
 
       - name: Publish
         if: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -38,6 +38,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "arrayvec"
@@ -83,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +105,12 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "cc"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -167,10 +185,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33fe99ccedd6e84bc035f1931bb2e6be79739d6242bd895e7311c886c50dc9c"
+dependencies = [
+ "matches",
+]
+
+[[package]]
 name = "deno_doc"
 version = "0.10.0"
 dependencies = [
  "clap",
+ "deno_graph",
  "futures",
  "lazy_static",
  "pretty_assertions",
@@ -178,10 +206,35 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_common",
- "swc_ecmascript",
+ "swc_ecmascript 0.53.0",
  "termcolor",
  "tokio",
  "url",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "deno_graph"
+version = "0.1.0"
+source = "git+https://github.com/kitsonk/deno_graph#451b72c108afc7c04deb88251b7c799c36cdd853"
+dependencies = [
+ "anyhow",
+ "data-url",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "regex",
+ "ring",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "swc_common",
+ "swc_ecmascript 0.52.1",
+ "termcolor",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -238,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -253,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -263,15 +316,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -280,16 +333,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -298,22 +352,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -419,6 +474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "js-sys"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -479,9 +544,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mio"
@@ -774,21 +839,35 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -810,18 +889,30 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.125"
+name = "serde-wasm-bindgen"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "1102fa7714968fcf70fd8efa29fb3b189e20ef0e7701fbab9634384dda034bf3"
+dependencies = [
+ "fnv",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -830,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "indexmap",
  "itoa",
@@ -866,6 +957,12 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -977,6 +1074,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_dep_graph"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e294566d33d6b32b9f1988116b67d06f85c1d3163b68163a4cd9f9abfa0b6e"
+dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_ecma_parser"
 version = "0.66.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1126,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c0f3969671267e85a7a387e2db40d01c0e7e6e979d7fd27bdeef501a2f6d14"
 dependencies = [
  "swc_ecma_ast",
+ "swc_ecma_dep_graph",
+ "swc_ecma_parser",
+]
+
+[[package]]
+name = "swc_ecmascript"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f19a5d10ac5504aa8cb57a2d6ea83cd73becbc7b55f346526ea04d264e13f4"
+dependencies = [
+ "swc_ecma_ast",
  "swc_ecma_parser",
 ]
 
@@ -1034,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ed2e930f5a1a4071fe62c90fd3a296f6030e5d94bfe13993244423caf59a78"
+checksum = "bf7c68e78ffbcba3d38abe6d0b76a0e1a37888b5c9301db3426537207090ada3"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1070,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1098,15 +1218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,9 +1234,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1183,15 +1294,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "url"
-version = "2.2.1"
+name = "untrusted"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -1205,6 +1323,84 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+dependencies = [
+ "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+
+[[package]]
+name = "web-sys"
+version = "0.3.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,41 +200,39 @@ dependencies = [
  "clap",
  "deno_graph",
  "futures",
+ "js-sys",
  "lazy_static",
  "pretty_assertions",
  "regex",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "swc_common",
- "swc_ecmascript 0.53.0",
+ "swc_ecmascript",
  "termcolor",
  "tokio",
- "url",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wee_alloc",
 ]
 
 [[package]]
 name = "deno_graph"
 version = "0.1.0"
-source = "git+https://github.com/kitsonk/deno_graph#451b72c108afc7c04deb88251b7c799c36cdd853"
+source = "git+https://github.com/kitsonk/deno_graph#f7f3a37e4892f804816c489dfce44855b506e665"
 dependencies = [
  "anyhow",
  "data-url",
  "futures",
- "js-sys",
  "lazy_static",
- "log",
  "regex",
  "ring",
  "serde",
- "serde-wasm-bindgen",
  "serde_json",
  "swc_common",
- "swc_ecmascript 0.52.1",
+ "swc_ecmascript",
  "termcolor",
  "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -405,15 +403,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -437,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -447,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -513,15 +511,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "lock_api"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -533,7 +531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
 ]
 
 [[package]]
@@ -549,10 +546,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
-name = "mio"
-version = "0.7.11"
+name = "memory_units"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -628,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "output_vt100"
@@ -702,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -761,9 +764,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -830,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -933,24 +936,24 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
+checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
@@ -1061,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.49.0"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033da686d95b9663e6732c4021e002bc23173bef251db87857e1c3c8bfbfe8cb"
+checksum = "28e5e369e3c177c792331c84ba7a7f2465035a3c5f25390641f8dccec0c08d6f"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1108,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06818a3a50e6de46a81d3d9f51a46d08624ff0f9eb2b3f30de717b15133858d"
+checksum = "754afc3c64e5f39fc17874170548e4f94612bcfb52fd7882437c149f713b3473"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1121,22 +1124,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.52.1"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0f3969671267e85a7a387e2db40d01c0e7e6e979d7fd27bdeef501a2f6d14"
+checksum = "c953b041665b5dda5ace749daedcc8358ccf1afb469fbd4301f1ca1a9b8f0f8e"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_dep_graph",
- "swc_ecma_parser",
-]
-
-[[package]]
-name = "swc_ecmascript"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f19a5d10ac5504aa8cb57a2d6ea83cd73becbc7b55f346526ea04d264e13f4"
-dependencies = [
- "swc_ecma_ast",
  "swc_ecma_parser",
 ]
 
@@ -1166,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583cfe83f6002e1118559308b88181f34b5936b403b72548cd0259bfcf0ca39e"
+checksum = "b24bd6153b94e06cae99d98d6a12b1fbe6063709cdb4b0f7ea25d2c0a62bdee7"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1219,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1254,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1274,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -1289,9 +1282,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "untrusted"
@@ -1400,6 +1393,18 @@ checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wee_alloc"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "memory_units",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,8 @@ dependencies = [
 [[package]]
 name = "deno_graph"
 version = "0.1.0"
-source = "git+https://github.com/kitsonk/deno_graph#f7f3a37e4892f804816c489dfce44855b506e665"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae0ab722f44da559fdf5b2a9192cac7763eb20b0ddb925e21116dff3da712fe"
 dependencies = [
  "anyhow",
  "data-url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "deno_doc"
 name = "ddoc"
 
 [dependencies]
-deno_graph = { git = "https://github.com/kitsonk/deno_graph" }
+deno_graph = "0.1.0"
 futures = "0.3.16"
 js-sys = { version = "0.3.52", optional = true }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["the Deno authors"]
 license = "MIT"
 
 [lib]
+crate-type = ["cdylib", "rlib"]
 name = "deno_doc"
 
 [[example]]
@@ -15,17 +16,31 @@ name = "ddoc"
 [dependencies]
 deno_graph = { git = "https://github.com/kitsonk/deno_graph" }
 futures = "0.3.16"
+js-sys = { version = "0.3.52", optional = true }
 lazy_static = "1.4.0"
 serde = { version = "1.0.127", features = ["derive"] }
 serde_json = { version = "1.0.66", features = [ "preserve_order" ] }
+serde-wasm-bindgen = { version = "0.3.0", optional = true }
 swc_common = "0.11.4"
-swc_ecmascript = { version = "0.53.0", features = ["parser"] }
+swc_ecmascript = { version = "0.54.0", features = ["parser"] }
 termcolor = "1.1.2"
 regex = "1.5.4"
-wasm-bindgen = { version = "0.2.75", features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2.75", features = ["serde-serialize"], optional = true }
+wasm-bindgen-futures = { version = "0.4.25", optional = true }
+wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 clap = "2.33.3"
 tokio = { version = "1.9.0", features = ["full"] }
-url = "2.2.2"
 pretty_assertions = "0.7.2"
+
+[features]
+default = ["rust"]
+rust = []
+wasm = ["js-sys", "serde-wasm-bindgen", "wasm-bindgen", "wasm-bindgen-futures", "wee_alloc"]
+
+[profile.release]
+codegen-units = 1
+incremental = true
+lto = true
+opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,19 @@ name = "deno_doc"
 name = "ddoc"
 
 [dependencies]
-futures = "0.3.14"
+deno_graph = { git = "https://github.com/kitsonk/deno_graph" }
+futures = "0.3.16"
 lazy_static = "1.4.0"
-serde = { version = "1.0.125", features = ["derive"] }
-serde_json = { version = "1.0.64", features = [ "preserve_order" ] }
+serde = { version = "1.0.127", features = ["derive"] }
+serde_json = { version = "1.0.66", features = [ "preserve_order" ] }
 swc_common = "0.11.4"
-swc_ecmascript = { version = "0.52.1", features = ["parser"] }
+swc_ecmascript = { version = "0.53.0", features = ["parser"] }
 termcolor = "1.1.2"
-regex = "=1.4.3"
+regex = "1.5.4"
+wasm-bindgen = { version = "0.2.75", features = ["serde-serialize"] }
 
 [dev-dependencies]
 clap = "2.33.3"
-tokio = { version = "1.5.0", features = ["full"] }
-url = "2.2.1"
+tokio = { version = "1.9.0", features = ["full"] }
+url = "2.2.2"
 pretty_assertions = "0.7.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,10 @@ pub use parser::DocError;
 pub use parser::DocParser;
 pub use printer::DocPrinter;
 
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -159,7 +159,7 @@ impl DocParser {
         .graph
         .resolve_dependency(specifier, referrer)
         .ok_or_else(|| DocError::Resolve(specifier.clone()))?;
-      let doc_nodes = self.parse_with_reexports(&resolved_specifier)?;
+      let doc_nodes = self.parse_with_reexports(resolved_specifier)?;
       let reexports_for_specifier = by_src.get(specifier).unwrap();
 
       for reexport in reexports_for_specifier {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::swc_util::AstParser;
 use crate::ReexportKind;
-use futures::future::LocalBoxFuture;
+use deno_graph::ModuleGraph;
+use deno_graph::ModuleSpecifier;
 use swc_common::comments::CommentKind;
 use swc_common::Span;
 use swc_ecmascript::ast::Decl;
@@ -21,7 +22,6 @@ use crate::node::ModuleDoc;
 use crate::swc_util;
 use crate::ImportDef;
 use crate::Location;
-use futures::FutureExt;
 use regex::Regex;
 use std::collections::HashMap;
 use std::error::Error;
@@ -53,19 +53,6 @@ impl From<swc_util::SwcDiagnosticBuffer> for DocError {
   }
 }
 
-pub trait DocFileLoader {
-  fn resolve(
-    &self,
-    specifier: &str,
-    referrer: &str,
-  ) -> Result<String, DocError>;
-
-  fn load_source_code(
-    &self,
-    specifier: &str,
-  ) -> LocalBoxFuture<Result<(Syntax, String), DocError>>;
-}
-
 #[derive(Clone)]
 enum ImportKind {
   Namespace(String),
@@ -80,15 +67,15 @@ struct Import {
 
 pub struct DocParser {
   pub ast_parser: AstParser,
-  pub loader: Box<dyn DocFileLoader>,
+  pub graph: ModuleGraph,
   pub private: bool,
 }
 
 impl DocParser {
-  pub fn new(loader: Box<dyn DocFileLoader>, private: bool) -> Self {
+  pub fn new(graph: ModuleGraph, private: bool) -> Self {
     DocParser {
-      loader,
       ast_parser: AstParser::default(),
+      graph,
       private,
     }
   }
@@ -97,17 +84,19 @@ impl DocParser {
   /// as well as a list of reexported items which need to be fetched from other modules.
   pub fn parse_module(
     &self,
-    file_name: &str,
+    specifier: &ModuleSpecifier,
     syntax: Syntax,
     source_code: &str,
   ) -> Result<ModuleDoc, DocError> {
     let parse_result =
-      self.ast_parser.parse_module(file_name, syntax, source_code);
+      self
+        .ast_parser
+        .parse_module(&specifier.to_string(), syntax, source_code);
     let module = parse_result?;
     let mut doc_entries =
       self.get_doc_nodes_for_module_body(module.body.clone());
     let import_doc_entries =
-      self.get_doc_nodes_for_module_imports(module.body.clone(), file_name)?;
+      self.get_doc_nodes_for_module_imports(module.body.clone(), specifier)?;
     doc_entries.extend(import_doc_entries);
     let reexports = self.get_reexports_for_module_body(module.body);
     let module_doc = ModuleDoc {
@@ -118,27 +107,39 @@ impl DocParser {
   }
 
   /// Fetches `file_name` and parses it.
-  pub async fn parse(&self, file_name: &str) -> Result<Vec<DocNode>, DocError> {
-    let (syntax, source_code) = self.loader.load_source_code(file_name).await?;
+  pub fn parse(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<Vec<DocNode>, DocError> {
+    let module = self
+      .graph
+      .try_get(specifier)
+      .map_err(|err| DocError::Resolve(err.to_string()))?
+      .ok_or_else(|| DocError::Resolve(specifier.to_string()))?;
 
-    self.parse_source(file_name, syntax, source_code.as_str())
+    self.parse_source(
+      &module.specifier,
+      Syntax::from(&module.media_type),
+      &module.source,
+    )
   }
 
   /// Parses a module and returns a list of exported items (no reexports).
   pub fn parse_source(
     &self,
-    file_name: &str,
+    specifier: &ModuleSpecifier,
     syntax: Syntax,
     source_code: &str,
   ) -> Result<Vec<DocNode>, DocError> {
-    let module_doc = self.parse_module(file_name, syntax, source_code)?;
-    Ok(module_doc.definitions)
+    self
+      .parse_module(specifier, syntax, source_code)
+      .map(|md| md.definitions)
   }
 
-  async fn flatten_reexports(
+  fn flatten_reexports(
     &self,
     reexports: &[node::Reexport],
-    referrer: &str,
+    referrer: &ModuleSpecifier,
   ) -> Result<Vec<DocNode>, DocError> {
     let mut by_src: HashMap<String, Vec<node::Reexport>> = HashMap::new();
 
@@ -154,8 +155,11 @@ impl DocParser {
     }
 
     for specifier in by_src.keys() {
-      let resolved_specifier = self.loader.resolve(specifier, referrer)?;
-      let doc_nodes = self.parse_with_reexports(&resolved_specifier).await?;
+      let resolved_specifier = self
+        .graph
+        .resolve_dependency(specifier, referrer)
+        .ok_or_else(|| DocError::Resolve(specifier.clone()))?;
+      let doc_nodes = self.parse_with_reexports(&resolved_specifier)?;
       let reexports_for_specifier = by_src.get(specifier).unwrap();
 
       for reexport in reexports_for_specifier {
@@ -210,35 +214,38 @@ impl DocParser {
   }
 
   /// Fetches `file_name`, parses it, and resolves its reexports.
-  pub fn parse_with_reexports<'a>(
-    &'a self,
-    file_name: &'a str,
-  ) -> LocalBoxFuture<Result<Vec<DocNode>, DocError>> {
-    async move {
-      let (syntax, source_code) =
-        self.loader.load_source_code(file_name).await?;
+  pub fn parse_with_reexports(
+    &self,
+    specifier: &ModuleSpecifier,
+  ) -> Result<Vec<DocNode>, DocError> {
+    let module = self
+      .graph
+      .try_get(specifier)
+      .map_err(|err| DocError::Resolve(err.to_string()))?
+      .ok_or_else(|| DocError::Resolve(specifier.to_string()))?;
 
-      let module_doc = self.parse_module(file_name, syntax, &source_code)?;
+    let module_doc = self.parse_module(
+      &module.specifier,
+      Syntax::from(&module.media_type),
+      &module.source,
+    )?;
 
-      let flattened_docs = if !module_doc.reexports.is_empty() {
-        let mut flattenned_reexports = self
-          .flatten_reexports(&module_doc.reexports, file_name)
-          .await?;
-        flattenned_reexports.extend(module_doc.definitions);
-        flattenned_reexports
-      } else {
-        module_doc.definitions
-      };
+    let flattened_docs = if !module_doc.reexports.is_empty() {
+      let mut flattenned_reexports =
+        self.flatten_reexports(&module_doc.reexports, &module.specifier)?;
+      flattenned_reexports.extend(module_doc.definitions);
+      flattenned_reexports
+    } else {
+      module_doc.definitions
+    };
 
-      Ok(flattened_docs)
-    }
-    .boxed_local()
+    Ok(flattened_docs)
   }
 
   fn get_doc_nodes_for_module_imports(
     &self,
     module_body: Vec<swc_ecmascript::ast::ModuleItem>,
-    referrer: &str,
+    referrer: &ModuleSpecifier,
   ) -> Result<Vec<DocNode>, DocError> {
     let mut imports = vec![];
 
@@ -273,9 +280,12 @@ impl DocParser {
             ),
           };
 
-          let resolved_specifier = self.loader.resolve(&src, referrer)?;
+          let resolved_specifier = self
+            .graph
+            .resolve_dependency(&src, referrer)
+            .ok_or_else(|| DocError::Resolve(src.clone()))?;
           let import_def = ImportDef {
-            src: resolved_specifier,
+            src: resolved_specifier.to_string(),
             imported: maybe_imported_name,
           };
 

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -20,18 +20,6 @@ use swc_ecmascript::parser::Parser;
 use swc_ecmascript::parser::StringInput;
 use swc_ecmascript::parser::Syntax;
 
-#[cfg(test)]
-use swc_ecmascript::parser::TsConfig;
-
-#[cfg(test)]
-pub fn get_default_ts_config() -> TsConfig {
-  TsConfig {
-    dynamic_import: true,
-    decorators: true,
-    ..Default::default()
-  }
-}
-
 #[derive(Clone, Debug)]
 pub struct SwcDiagnosticBuffer {
   pub diagnostics: Vec<String>,


### PR DESCRIPTION
This integrates `deno_graph` and lays down the prep work for exposing a web assembly API for `deno_graph`.