### PR TITLE
feat: handle @ignore tags internally

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -10,6 +10,7 @@ use crate::decorators::DecoratorDef;
 use crate::function::function_to_function_def;
 use crate::function::FunctionDef;
 use crate::js_doc::JsDoc;
+use crate::js_doc::JsDocTag;
 use crate::node::DeclarationKind;
 use crate::params::assign_pat_to_param_def;
 use crate::params::ident_to_param_def;
@@ -286,110 +287,117 @@ pub fn class_to_class_def(
     match member {
       Constructor(ctor) => {
         let ctor_js_doc = js_doc_for_range(parsed_source, &ctor.range());
-        let constructor_name =
-          prop_name_to_string(Some(parsed_source), &ctor.key);
 
-        let mut params = vec![];
+        if !ctor_js_doc.tags.contains(&JsDocTag::Ignore) {
+          let constructor_name =
+            prop_name_to_string(Some(parsed_source), &ctor.key);
 
-        for param in &ctor.params {
-          use deno_ast::swc::ast::ParamOrTsParamProp::*;
+          let mut params = vec![];
 
-          let param_def = match param {
-            Param(param) => ClassConstructorParamDef {
-              accessibility: None,
-              is_override: false,
-              param: param_to_param_def(parsed_source, param),
-              readonly: false,
-            },
-            TsParamProp(ts_param_prop) => {
-              use deno_ast::swc::ast::TsParamPropParam;
+          for param in &ctor.params {
+            use deno_ast::swc::ast::ParamOrTsParamProp::*;
 
-              let param = match &ts_param_prop.param {
-                TsParamPropParam::Ident(ident) => {
-                  ident_to_param_def(Some(parsed_source), ident)
+            let param_def = match param {
+              Param(param) => ClassConstructorParamDef {
+                accessibility: None,
+                is_override: false,
+                param: param_to_param_def(parsed_source, param),
+                readonly: false,
+              },
+              TsParamProp(ts_param_prop) => {
+                use deno_ast::swc::ast::TsParamPropParam;
+
+                let param = match &ts_param_prop.param {
+                  TsParamPropParam::Ident(ident) => {
+                    ident_to_param_def(Some(parsed_source), ident)
+                  }
+                  TsParamPropParam::Assign(assign_pat) => {
+                    assign_pat_to_param_def(Some(parsed_source), assign_pat)
+                  }
+                };
+
+                ClassConstructorParamDef {
+                  accessibility: ts_param_prop.accessibility,
+                  is_override: ts_param_prop.is_override,
+                  param,
+                  readonly: ts_param_prop.readonly,
                 }
-                TsParamPropParam::Assign(assign_pat) => {
-                  assign_pat_to_param_def(Some(parsed_source), assign_pat)
-                }
-              };
-
-              ClassConstructorParamDef {
-                accessibility: ts_param_prop.accessibility,
-                is_override: ts_param_prop.is_override,
-                param,
-                readonly: ts_param_prop.readonly,
               }
-            }
-          };
-          params.push(param_def);
-        }
+            };
+            params.push(param_def);
+          }
 
-        let constructor_def = ClassConstructorDef {
-          js_doc: ctor_js_doc,
-          accessibility: ctor.accessibility,
-          is_optional: ctor.is_optional,
-          has_body: ctor.body.is_some(),
-          name: constructor_name,
-          params,
-          location: get_location(parsed_source, ctor.start()),
-        };
-        constructors.push(constructor_def);
+          let constructor_def = ClassConstructorDef {
+            js_doc: ctor_js_doc,
+            accessibility: ctor.accessibility,
+            is_optional: ctor.is_optional,
+            has_body: ctor.body.is_some(),
+            name: constructor_name,
+            params,
+            location: get_location(parsed_source, ctor.start()),
+          };
+          constructors.push(constructor_def);
+        }
       }
       Method(class_method) => {
         let method_js_doc =
           js_doc_for_range(parsed_source, &class_method.range());
-        let method_name =
-          prop_name_to_string(Some(parsed_source), &class_method.key);
-        let fn_def =
-          function_to_function_def(parsed_source, &class_method.function);
-        let method_def = ClassMethodDef {
-          js_doc: method_js_doc,
-          accessibility: class_method.accessibility,
-          optional: class_method.is_optional,
-          is_abstract: class_method.is_abstract,
-          is_static: class_method.is_static,
-          is_override: class_method.is_override,
-          name: method_name,
-          kind: class_method.kind,
-          function_def: fn_def,
-          location: get_location(parsed_source, class_method.start()),
-        };
-        methods.push(method_def);
+        if !method_js_doc.tags.contains(&JsDocTag::Ignore) {
+          let method_name =
+            prop_name_to_string(Some(parsed_source), &class_method.key);
+          let fn_def =
+            function_to_function_def(parsed_source, &class_method.function);
+          let method_def = ClassMethodDef {
+            js_doc: method_js_doc,
+            accessibility: class_method.accessibility,
+            optional: class_method.is_optional,
+            is_abstract: class_method.is_abstract,
+            is_static: class_method.is_static,
+            is_override: class_method.is_override,
+            name: method_name,
+            kind: class_method.kind,
+            function_def: fn_def,
+            location: get_location(parsed_source, class_method.start()),
+          };
+          methods.push(method_def);
+        }
       }
       ClassProp(class_prop) => {
         let prop_js_doc = js_doc_for_range(parsed_source, &class_prop.range());
 
-        let ts_type = if let Some(type_ann) = &class_prop.type_ann {
-          // if the property has a type annotation, use it
-          Some(ts_type_ann_to_def(type_ann))
-        } else if let Some(value) = &class_prop.value {
-          // else, if it has an initializer, try to infer the type
-          infer_ts_type_from_expr(parsed_source, value, false)
-        } else {
-          // else, none
-          None
-        };
+        if !prop_js_doc.tags.contains(&JsDocTag::Ignore) {
+          let ts_type = if let Some(type_ann) = &class_prop.type_ann {
+            // if the property has a type annotation, use it
+            Some(ts_type_ann_to_def(type_ann))
+          } else if let Some(value) = &class_prop.value {
+            // else, if it has an initializer, try to infer the type
+            infer_ts_type_from_expr(parsed_source, value, false)
+          } else {
+            // else, none
+            None
+          };
 
-        let prop_name =
-          prop_name_to_string(Some(parsed_source), &class_prop.key);
+          let prop_name =
+            prop_name_to_string(Some(parsed_source), &class_prop.key);
 
-        let decorators =
-          decorators_to_defs(parsed_source, &class_prop.decorators);
+          let decorators =
+            decorators_to_defs(parsed_source, &class_prop.decorators);
 
-        let prop_def = ClassPropertyDef {
-          js_doc: prop_js_doc,
-          ts_type,
-          readonly: class_prop.readonly,
-          optional: class_prop.is_optional,
-          is_abstract: class_prop.is_abstract,
-          is_static: class_prop.is_static,
-          is_override: class_prop.is_override,
-          accessibility: class_prop.accessibility,
-          name: prop_name,
-          decorators,
-          location: get_location(parsed_source, class_prop.start()),
-        };
-        properties.push(prop_def);
+          let prop_def = ClassPropertyDef {
+            js_doc: prop_js_doc,
+            ts_type,
+            readonly: class_prop.readonly,
+            optional: class_prop.is_optional,
+            is_abstract: class_prop.is_abstract,
+            is_static: class_prop.is_static,
+            is_override: class_prop.is_override,
+            accessibility: class_prop.accessibility,
+            name: prop_name,
+            decorators,
+            location: get_location(parsed_source, class_prop.start()),
+          };
+          properties.push(prop_def);
+        }
       }
       TsIndexSignature(ts_index_sig) => {
         let mut params = vec![];
@@ -434,6 +442,8 @@ pub fn class_to_class_def(
   } else {
     JsDoc::default()
   };
+
+  // TODO
 
   (
     ClassDef {

--- a/src/class.rs
+++ b/src/class.rs
@@ -10,7 +10,6 @@ use crate::decorators::DecoratorDef;
 use crate::function::function_to_function_def;
 use crate::function::FunctionDef;
 use crate::js_doc::JsDoc;
-use crate::js_doc::JsDocTag;
 use crate::node::DeclarationKind;
 use crate::params::assign_pat_to_param_def;
 use crate::params::ident_to_param_def;
@@ -286,9 +285,9 @@ pub fn class_to_class_def(
 
     match member {
       Constructor(ctor) => {
-        let ctor_js_doc = js_doc_for_range(parsed_source, &ctor.range());
-
-        if !ctor_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(ctor_js_doc) =
+          js_doc_for_range(parsed_source, &ctor.range())
+        {
           let constructor_name =
             prop_name_to_string(Some(parsed_source), &ctor.key);
 
@@ -340,9 +339,9 @@ pub fn class_to_class_def(
         }
       }
       Method(class_method) => {
-        let method_js_doc =
-          js_doc_for_range(parsed_source, &class_method.range());
-        if !method_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(method_js_doc) =
+          js_doc_for_range(parsed_source, &class_method.range())
+        {
           let method_name =
             prop_name_to_string(Some(parsed_source), &class_method.key);
           let fn_def =
@@ -363,9 +362,9 @@ pub fn class_to_class_def(
         }
       }
       ClassProp(class_prop) => {
-        let prop_js_doc = js_doc_for_range(parsed_source, &class_prop.range());
-
-        if !prop_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(prop_js_doc) =
+          js_doc_for_range(parsed_source, &class_prop.range())
+        {
           let ts_type = if let Some(type_ann) = &class_prop.type_ann {
             // if the property has a type annotation, use it
             Some(ts_type_ann_to_def(type_ann))
@@ -440,10 +439,11 @@ pub fn class_to_class_def(
   let js_doc = if !class.decorators.is_empty() {
     js_doc_for_range(parsed_source, &class.decorators[0].range())
   } else {
-    JsDoc::default()
+    Some(JsDoc::default())
   };
 
   // TODO
+  let js_doc = js_doc.unwrap_or_default();
 
   (
     ClassDef {

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -5,7 +5,7 @@ use deno_ast::SourceRangedForSpanned;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::js_doc::{JsDoc, JsDocTag};
+use crate::js_doc::JsDoc;
 use crate::swc_util::get_location;
 use crate::swc_util::js_doc_for_range;
 use crate::ts_type::infer_ts_type_from_expr;
@@ -39,9 +39,8 @@ pub fn get_doc_for_ts_enum_decl(
   for enum_member in &enum_decl.members {
     use deno_ast::swc::ast::TsEnumMemberId::*;
 
-    let js_doc = js_doc_for_range(parsed_source, &enum_member.range());
-
-    if !js_doc.tags.contains(&JsDocTag::Ignore) {
+    if let Some(js_doc) = js_doc_for_range(parsed_source, &enum_member.range())
+    {
       let name = match &enum_member.id {
         Ident(ident) => ident.sym.to_string(),
         Str(str_) => str_.value.to_string(),

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::function::FunctionDef;
-use crate::js_doc::{JsDoc, JsDocTag};
+use crate::js_doc::JsDoc;
 use crate::node::DeclarationKind;
 use crate::params::ts_fn_param_to_param_def;
 use crate::swc_util::get_location;
@@ -238,10 +238,9 @@ pub fn get_doc_for_ts_interface_decl(
 
     match &type_element {
       TsMethodSignature(ts_method_sig) => {
-        let method_js_doc =
-          js_doc_for_range(parsed_source, &ts_method_sig.range());
-
-        if !method_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(method_js_doc) =
+          js_doc_for_range(parsed_source, &ts_method_sig.range())
+        {
           let mut params = vec![];
 
           for param in &ts_method_sig.params {
@@ -274,10 +273,9 @@ pub fn get_doc_for_ts_interface_decl(
         }
       }
       TsGetterSignature(ts_getter_sig) => {
-        let method_js_doc =
-          js_doc_for_range(parsed_source, &ts_getter_sig.range());
-
-        if !method_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(method_js_doc) =
+          js_doc_for_range(parsed_source, &ts_getter_sig.range())
+        {
           let name = expr_to_name(&ts_getter_sig.key);
 
           let maybe_return_type =
@@ -298,10 +296,9 @@ pub fn get_doc_for_ts_interface_decl(
         }
       }
       TsSetterSignature(ts_setter_sig) => {
-        let method_js_doc =
-          js_doc_for_range(parsed_source, &ts_setter_sig.range());
-
-        if !method_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(method_js_doc) =
+          js_doc_for_range(parsed_source, &ts_setter_sig.range())
+        {
           let name = expr_to_name(&ts_setter_sig.key);
 
           let param_def =
@@ -323,9 +320,9 @@ pub fn get_doc_for_ts_interface_decl(
         }
       }
       TsPropertySignature(ts_prop_sig) => {
-        let prop_js_doc = js_doc_for_range(parsed_source, &ts_prop_sig.range());
-
-        if !prop_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(prop_js_doc) =
+          js_doc_for_range(parsed_source, &ts_prop_sig.range())
+        {
           let name = expr_to_name(&ts_prop_sig.key);
 
           let mut params = vec![];
@@ -357,10 +354,9 @@ pub fn get_doc_for_ts_interface_decl(
         }
       }
       TsCallSignatureDecl(ts_call_sig) => {
-        let call_sig_js_doc =
-          js_doc_for_range(parsed_source, &ts_call_sig.range());
-
-        if !call_sig_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(call_sig_js_doc) =
+          js_doc_for_range(parsed_source, &ts_call_sig.range())
+        {
           let mut params = vec![];
           for param in &ts_call_sig.params {
             let param_def =
@@ -405,10 +401,9 @@ pub fn get_doc_for_ts_interface_decl(
         index_signatures.push(index_sig_def);
       }
       TsConstructSignatureDecl(ts_construct_sig) => {
-        let construct_js_doc =
-          js_doc_for_range(parsed_source, &ts_construct_sig.range());
-
-        if !construct_js_doc.tags.contains(&JsDocTag::Ignore) {
+        if let Some(construct_js_doc) =
+          js_doc_for_range(parsed_source, &ts_construct_sig.range())
+        {
           let mut params = vec![];
 
           for param in &ts_construct_sig.params {

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,6 +1,5 @@
 // Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
 
-use crate::js_doc::JsDocTag;
 use deno_ast::ParsedSource;
 use deno_ast::SourceRanged;
 use deno_ast::SourceRangedForSpanned;
@@ -20,130 +19,128 @@ pub fn get_doc_node_for_export_decl(
   use deno_ast::swc::ast::Decl;
 
   let export_range = export_decl.range();
-  let js_doc = js_doc_for_range(parsed_source, &export_range);
+  if let Some(js_doc) = js_doc_for_range(parsed_source, &export_range) {
+    let location = get_location(parsed_source, export_range.start());
 
-  if js_doc.tags.contains(&JsDocTag::Ignore) {
-    return vec![];
-  }
-
-  let location = get_location(parsed_source, export_range.start());
-
-  match &export_decl.decl {
-    Decl::Class(class_decl) => {
-      let (name, class_def, decorator_js_doc) =
-        super::class::get_doc_for_class_decl(parsed_source, class_decl);
-      let js_doc = if js_doc.is_empty() {
-        decorator_js_doc
-      } else {
-        js_doc
-      };
-      vec![DocNode::class(
-        name,
-        location,
-        DeclarationKind::Export,
-        js_doc,
-        class_def,
-      )]
-    }
-    Decl::Fn(fn_decl) => {
-      let (name, fn_def) =
-        super::function::get_doc_for_fn_decl(parsed_source, fn_decl);
-      vec![DocNode::function(
-        name,
-        location,
-        DeclarationKind::Export,
-        js_doc,
-        fn_def,
-      )]
-    }
-    Decl::Var(var_decl) => super::variable::get_doc_for_var_decl(
-      parsed_source,
-      var_decl,
-      previous_nodes,
-    )
-    .into_iter()
-    .filter_map(|(name, var_def, maybe_range)| {
-      let js_doc = if js_doc.is_empty() {
-        js_doc_for_range(
-          parsed_source,
-          &maybe_range.unwrap_or_else(|| var_decl.range()),
-        )
-      } else {
-        js_doc.clone()
-      };
-
-      if js_doc.tags.contains(&JsDocTag::Ignore) {
-        None
-      } else {
-        let location = get_location(
-          parsed_source,
-          maybe_range
-            .map(|range| range.start)
-            .unwrap_or_else(|| var_decl.start()),
-        );
-
-        Some(DocNode::variable(
+    match &export_decl.decl {
+      Decl::Class(class_decl) => {
+        let (name, class_def, decorator_js_doc) =
+          super::class::get_doc_for_class_decl(parsed_source, class_decl);
+        let js_doc = if js_doc.is_empty() {
+          decorator_js_doc
+        } else {
+          js_doc
+        };
+        vec![DocNode::class(
           name,
           location,
           DeclarationKind::Export,
           js_doc,
-          var_def,
-        ))
+          class_def,
+        )]
       }
-    })
-    .collect(),
-    Decl::TsInterface(ts_interface_decl) => {
-      let (name, interface_def) =
-        super::interface::get_doc_for_ts_interface_decl(
-          parsed_source,
-          ts_interface_decl,
-        );
-      vec![DocNode::interface(
-        name,
-        location,
-        DeclarationKind::Export,
-        js_doc,
-        interface_def,
-      )]
-    }
-    Decl::TsTypeAlias(ts_type_alias) => {
-      let (name, type_alias_def) =
-        super::type_alias::get_doc_for_ts_type_alias_decl(
-          parsed_source,
-          ts_type_alias,
-        );
-      vec![DocNode::type_alias(
-        name,
-        location,
-        DeclarationKind::Export,
-        js_doc,
-        type_alias_def,
-      )]
-    }
-    Decl::TsEnum(ts_enum) => {
-      let (name, enum_def) =
-        super::r#enum::get_doc_for_ts_enum_decl(parsed_source, ts_enum);
-      vec![DocNode::r#enum(
-        name,
-        location,
-        DeclarationKind::Export,
-        js_doc,
-        enum_def,
-      )]
-    }
-    Decl::TsModule(ts_module) => {
-      let (name, namespace_def) = super::namespace::get_doc_for_ts_module(
-        doc_parser,
+      Decl::Fn(fn_decl) => {
+        let (name, fn_def) =
+          super::function::get_doc_for_fn_decl(parsed_source, fn_decl);
+        vec![DocNode::function(
+          name,
+          location,
+          DeclarationKind::Export,
+          js_doc,
+          fn_def,
+        )]
+      }
+      Decl::Var(var_decl) => super::variable::get_doc_for_var_decl(
         parsed_source,
-        ts_module,
-      );
-      vec![DocNode::namespace(
-        name,
-        location,
-        DeclarationKind::Export,
-        js_doc,
-        namespace_def,
-      )]
+        var_decl,
+        previous_nodes,
+      )
+      .into_iter()
+      .filter_map(|(name, var_def, maybe_range)| {
+        let js_doc = if js_doc.is_empty() {
+          js_doc_for_range(
+            parsed_source,
+            &maybe_range.unwrap_or_else(|| var_decl.range()),
+          )
+        } else {
+          Some(js_doc.clone())
+        };
+
+        if let Some(js_doc) = js_doc {
+          let location = get_location(
+            parsed_source,
+            maybe_range
+              .map(|range| range.start)
+              .unwrap_or_else(|| var_decl.start()),
+          );
+
+          Some(DocNode::variable(
+            name,
+            location,
+            DeclarationKind::Export,
+            js_doc,
+            var_def,
+          ))
+        } else {
+          None
+        }
+      })
+      .collect(),
+      Decl::TsInterface(ts_interface_decl) => {
+        let (name, interface_def) =
+          super::interface::get_doc_for_ts_interface_decl(
+            parsed_source,
+            ts_interface_decl,
+          );
+        vec![DocNode::interface(
+          name,
+          location,
+          DeclarationKind::Export,
+          js_doc,
+          interface_def,
+        )]
+      }
+      Decl::TsTypeAlias(ts_type_alias) => {
+        let (name, type_alias_def) =
+          super::type_alias::get_doc_for_ts_type_alias_decl(
+            parsed_source,
+            ts_type_alias,
+          );
+        vec![DocNode::type_alias(
+          name,
+          location,
+          DeclarationKind::Export,
+          js_doc,
+          type_alias_def,
+        )]
+      }
+      Decl::TsEnum(ts_enum) => {
+        let (name, enum_def) =
+          super::r#enum::get_doc_for_ts_enum_decl(parsed_source, ts_enum);
+        vec![DocNode::r#enum(
+          name,
+          location,
+          DeclarationKind::Export,
+          js_doc,
+          enum_def,
+        )]
+      }
+      Decl::TsModule(ts_module) => {
+        let (name, namespace_def) = super::namespace::get_doc_for_ts_module(
+          doc_parser,
+          parsed_source,
+          ts_module,
+        );
+        vec![DocNode::namespace(
+          name,
+          location,
+          DeclarationKind::Export,
+          js_doc,
+          namespace_def,
+        )]
+      }
     }
+  } else {
+    vec![]
   }
 }


### PR DESCRIPTION
unsure if we should remove the typings: the api will never give ignore tags, but the rust API of deno_doc will still have it part of the JsDocTag enum, so it would mismatch. Maybe no-doc the Ignore tag?