### PR TITLE
feat: ignore diagnostics on nodes with `@internal` tag

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,9 +1,12 @@
 // Copyright 2020-2023 the Deno authors. All rights reserved. MIT license.
 
+use crate::js_doc::JsDoc;
+use crate::js_doc::JsDocTag;
 use crate::node::DeclarationKind;
 use crate::node::DocNode;
 use crate::node::NamespaceDef;
 use crate::swc_util::get_location;
+use crate::ts_type::TsTypeDef;
 use crate::variable::VariableDef;
 use crate::DocNodeKind;
 use crate::Location;
@@ -20,7 +23,8 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DocDiagnosticKind {
   MissingJsDoc,
-  MissingTypeRef,
+  MissingExplicitType,
+  MissingReturnType,
   PrivateTypeRef,
 }
 
@@ -30,8 +34,11 @@ impl std::fmt::Display for DocDiagnosticKind {
       DocDiagnosticKind::MissingJsDoc => {
         f.write_str("Missing JS documentation comment.")
       }
-      DocDiagnosticKind::MissingTypeRef => {
+      DocDiagnosticKind::MissingExplicitType => {
         f.write_str("Missing explicit type.")
+      }
+      DocDiagnosticKind::MissingReturnType => {
+        f.write_str("Missing return type.")
       }
       DocDiagnosticKind::PrivateTypeRef => {
         f.write_str("Type is not exported, but referenced by an exported type.")
@@ -83,8 +90,11 @@ impl DiagnosticsCollector {
     DiagnosticDocNodeVisitor { diagnostics: self }.visit_doc_nodes(doc_nodes)
   }
 
-  fn add_missing_js_doc(&mut self, location: &Location) {
-    if self.seen_jsdoc_missing.insert(location.clone()) {
+  fn check_missing_js_doc(&mut self, js_doc: &JsDoc, location: &Location) {
+    if js_doc.doc.is_none()
+      && !has_internal_js_doc_tag(js_doc)
+      && self.seen_jsdoc_missing.insert(location.clone())
+    {
       self.diagnostics.push(DocDiagnostic {
         location: location.clone(),
         kind: DocDiagnosticKind::MissingJsDoc,
@@ -92,11 +102,36 @@ impl DiagnosticsCollector {
     }
   }
 
-  fn add_missing_type_ref(&mut self, location: &Location) {
-    if self.seen_missing_type_refs.insert(location.clone()) {
+  fn check_missing_explicit_type(
+    &mut self,
+    ts_type: Option<&TsTypeDef>,
+    js_doc: &JsDoc,
+    location: &Location,
+  ) {
+    if ts_type.is_none()
+      && !has_internal_js_doc_tag(js_doc)
+      && self.seen_missing_type_refs.insert(location.clone())
+    {
       self.diagnostics.push(DocDiagnostic {
         location: location.clone(),
-        kind: DocDiagnosticKind::MissingTypeRef,
+        kind: DocDiagnosticKind::MissingExplicitType,
+      })
+    }
+  }
+
+  fn check_missing_return_type(
+    &mut self,
+    return_type: Option<&TsTypeDef>,
+    js_doc: &JsDoc,
+    location: &Location,
+  ) {
+    if return_type.is_none()
+      && !has_internal_js_doc_tag(js_doc)
+      && self.seen_missing_type_refs.insert(location.clone())
+    {
+      self.diagnostics.push(DocDiagnostic {
+        location: location.clone(),
+        kind: DocDiagnosticKind::MissingReturnType,
       })
     }
   }
@@ -144,8 +179,10 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
       return; // skip, we don't do these diagnostics above private nodes
     }
 
-    if doc_node.js_doc.doc.is_none() && is_js_docable_kind(&doc_node.kind) {
-      self.diagnostics.add_missing_js_doc(&doc_node.location);
+    if is_js_docable_kind(&doc_node.kind) {
+      self
+        .diagnostics
+        .check_missing_js_doc(&doc_node.js_doc, &doc_node.location);
     }
 
     if let Some(def) = &doc_node.class_def {
@@ -186,22 +223,26 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
       if prop.accessibility == Some(Accessibility::Private) {
         continue; // don't do diagnostics for private types
       }
-      if prop.js_doc.doc.is_none() {
-        self.diagnostics.add_missing_js_doc(&prop.location);
-      }
-      if prop.ts_type.is_none() {
-        self.diagnostics.add_missing_type_ref(&prop.location)
-      }
+      self
+        .diagnostics
+        .check_missing_js_doc(&prop.js_doc, &prop.location);
+      self.diagnostics.check_missing_explicit_type(
+        prop.ts_type.as_ref(),
+        &prop.js_doc,
+        &prop.location,
+      )
     }
 
     // index signatures
     for sig in &def.index_signatures {
-      if sig.js_doc.doc.is_none() {
-        self.diagnostics.add_missing_js_doc(&sig.location);
-      }
-      if sig.ts_type.is_none() {
-        self.diagnostics.add_missing_type_ref(&sig.location)
-      }
+      self
+        .diagnostics
+        .check_missing_js_doc(&sig.js_doc, &sig.location);
+      self.diagnostics.check_missing_explicit_type(
+        sig.ts_type.as_ref(),
+        &sig.js_doc,
+        &sig.location,
+      )
     }
 
     // methods
@@ -212,21 +253,24 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
           continue; // skip, it's the implementation signature
         }
       }
-      if method.js_doc.doc.is_none() {
-        self.diagnostics.add_missing_js_doc(&method.location);
-      }
-      if method.function_def.return_type.is_none() {
-        self.diagnostics.add_missing_type_ref(&method.location)
-      }
+
+      self
+        .diagnostics
+        .check_missing_js_doc(&method.js_doc, &method.location);
+      self.diagnostics.check_missing_return_type(
+        method.function_def.return_type.as_ref(),
+        &method.js_doc,
+        &method.location,
+      );
 
       last_name = Some(&method.name);
     }
   }
 
   fn visit_class_ctor_def(&mut self, ctor: &crate::class::ClassConstructorDef) {
-    if ctor.js_doc.doc.is_none() {
-      self.diagnostics.add_missing_js_doc(&ctor.location);
-    }
+    self
+      .diagnostics
+      .check_missing_js_doc(&ctor.js_doc, &ctor.location);
   }
 
   fn visit_function_def(
@@ -234,43 +278,52 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
     parent: &DocNode,
     def: &crate::function::FunctionDef,
   ) {
-    if parent.js_doc.doc.is_none() {
-      self.diagnostics.add_missing_js_doc(&parent.location);
-    }
-    if def.return_type.is_none() {
-      self.diagnostics.add_missing_type_ref(&parent.location)
-    }
+    self
+      .diagnostics
+      .check_missing_js_doc(&parent.js_doc, &parent.location);
+    self.diagnostics.check_missing_return_type(
+      def.return_type.as_ref(),
+      &parent.js_doc,
+      &parent.location,
+    );
   }
 
   fn visit_interface_def(&mut self, def: &crate::interface::InterfaceDef) {
     // properties
     for prop in &def.properties {
-      if prop.js_doc.doc.is_none() {
-        self.diagnostics.add_missing_js_doc(&prop.location);
-      }
-      if prop.ts_type.is_none() {
-        self.diagnostics.add_missing_type_ref(&prop.location)
-      }
+      self
+        .diagnostics
+        .check_missing_js_doc(&prop.js_doc, &prop.location);
+
+      self.diagnostics.check_missing_explicit_type(
+        prop.ts_type.as_ref(),
+        &prop.js_doc,
+        &prop.location,
+      )
     }
 
     // index signatures
     for sig in &def.index_signatures {
-      if sig.js_doc.doc.is_none() {
-        self.diagnostics.add_missing_js_doc(&sig.location);
-      }
-      if sig.ts_type.is_none() {
-        self.diagnostics.add_missing_type_ref(&sig.location)
-      }
+      self
+        .diagnostics
+        .check_missing_js_doc(&sig.js_doc, &sig.location);
+      self.diagnostics.check_missing_explicit_type(
+        sig.ts_type.as_ref(),
+        &sig.js_doc,
+        &sig.location,
+      );
     }
 
     // methods
     for method in &def.methods {
-      if method.js_doc.doc.is_none() {
-        self.diagnostics.add_missing_js_doc(&method.location);
-      }
-      if method.return_type.is_none() {
-        self.diagnostics.add_missing_type_ref(&method.location)
-      }
+      self
+        .diagnostics
+        .check_missing_js_doc(&method.js_doc, &method.location);
+      self.diagnostics.check_missing_return_type(
+        method.return_type.as_ref(),
+        &method.js_doc,
+        &method.location,
+      );
     }
   }
 
@@ -279,8 +332,21 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
   }
 
   fn visit_variable_def(&mut self, parent: &DocNode, def: &VariableDef) {
-    if def.ts_type.is_none() {
-      self.diagnostics.add_missing_type_ref(&parent.location);
-    }
+    self.diagnostics.check_missing_explicit_type(
+      def.ts_type.as_ref(),
+      &parent.js_doc,
+      &parent.location,
+    );
   }
+}
+
+fn has_internal_js_doc_tag(js_doc: &JsDoc) -> bool {
+  js_doc.tags.iter().any(|t| match t {
+    JsDocTag::Unsupported { value }
+      if value == "@internal" || value.starts_with("@internal ") =>
+    {
+      true
+    }
+    _ => false,
+  })
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -64,10 +64,15 @@ pub struct DiagnosticsCollector {
 impl DiagnosticsCollector {
   pub fn add_private_type_in_public(
     &mut self,
+    doc_node: &DocNode,
     module: &EsmModuleSymbol,
     symbol_id: SymbolId,
     range: SourceRange,
   ) {
+    if has_internal_js_doc_tag(&doc_node.js_doc) {
+      return; // ignore
+    }
+
     let unique_id = UniqueSymbolId {
       module_id: module.module_id(),
       symbol_id,
@@ -155,7 +160,9 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
         }
       }
 
-      self.visit_doc_node(doc_node);
+      if !has_internal_js_doc_tag(&doc_node.js_doc) {
+        self.visit_doc_node(doc_node);
+      }
 
       last_node = Some(doc_node);
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -348,12 +348,5 @@ impl<'a> DiagnosticDocNodeVisitor<'a> {
 }
 
 fn has_internal_js_doc_tag(js_doc: &JsDoc) -> bool {
-  js_doc.tags.iter().any(|t| match t {
-    JsDocTag::Unsupported { value }
-      if value == "@internal" || value.starts_with("@internal ") =>
-    {
-      true
-    }
-    _ => false,
-  })
+  js_doc.tags.iter().any(|t| matches!(t, JsDocTag::Unsupported { value } if value == "@internal" || value.starts_with("@internal ")))
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -636,6 +636,7 @@ impl<'a> DocParser<'a> {
                 if is_public {
                   if let Some(diagnostics) = &self.diagnostics {
                     diagnostics.borrow_mut().add_private_type_in_public(
+                      &doc_node,
                       module_symbol,
                       symbol.symbol_id(),
                       decl.range,
@@ -1014,6 +1015,7 @@ impl<'a> DocParser<'a> {
                 if is_public {
                   if let Some(diagnostics) = &self.diagnostics {
                     diagnostics.borrow_mut().add_private_type_in_public(
+                      &doc_node,
                       module_symbol,
                       child_symbol.symbol_id(),
                       decl.range,

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -33,7 +33,7 @@ impl Spec {
     if !self.diagnostics.is_empty() {
       text.push_str("# diagnostics\n");
       text.push_str(&serde_json::to_string_pretty(&self.diagnostics).unwrap());
-      text.push('\n');
+      text.push_str("\n\n");
     }
     text.push_str(&self.output_doc_file.emit());
     text.push('\n');

--- a/tests/specs/AbstractClass.txt
+++ b/tests/specs/AbstractClass.txt
@@ -5,6 +5,7 @@ export abstract class Class {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/AbstractClassAbstractMethod.txt
+++ b/tests/specs/AbstractClassAbstractMethod.txt
@@ -7,8 +7,9 @@ export abstract class Class {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type."
+  "file:///mod.ts:2:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassAsyncMethod.txt
+++ b/tests/specs/ClassAsyncMethod.txt
@@ -7,8 +7,9 @@ export class Class {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type."
+  "file:///mod.ts:2:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassConstructor.txt
+++ b/tests/specs/ClassConstructor.txt
@@ -8,6 +8,7 @@ export class Class {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassDeclaration.txt
+++ b/tests/specs/ClassDeclaration.txt
@@ -5,6 +5,7 @@ export class Class {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassDecorators.txt
+++ b/tests/specs/ClassDecorators.txt
@@ -22,10 +22,11 @@ export class A {
   "file:///mod.ts:2:1 Missing JS documentation comment.",
   "file:///mod.ts:5:3 Missing JS documentation comment.",
   "file:///mod.ts:8:3 Missing JS documentation comment.",
-  "file:///mod.ts:8:3 Missing explicit type.",
+  "file:///mod.ts:8:3 Missing return type.",
   "file:///mod.ts:13:3 Missing JS documentation comment.",
-  "file:///mod.ts:13:3 Missing explicit type."
+  "file:///mod.ts:13:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/ClassDetails.txt
+++ b/tests/specs/ClassDetails.txt
@@ -9,8 +9,9 @@ export class C {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:4:3 Missing JS documentation comment.",
-  "file:///mod.ts:3:3 Missing explicit type."
+  "file:///mod.ts:3:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassDetailsAllWithPrivate.txt
+++ b/tests/specs/ClassDetailsAllWithPrivate.txt
@@ -10,12 +10,13 @@ export class Class {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type.",
+  "file:///mod.ts:2:3 Missing return type.",
   "file:///mod.ts:3:3 Missing JS documentation comment.",
-  "file:///mod.ts:3:3 Missing explicit type.",
+  "file:///mod.ts:3:3 Missing return type.",
   "file:///mod.ts:4:3 Missing JS documentation comment.",
-  "file:///mod.ts:4:3 Missing explicit type."
+  "file:///mod.ts:4:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassDetailsOnlyNonPrivateWithoutPrivate.txt
+++ b/tests/specs/ClassDetailsOnlyNonPrivateWithoutPrivate.txt
@@ -9,12 +9,13 @@ export class Class {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type.",
+  "file:///mod.ts:2:3 Missing return type.",
   "file:///mod.ts:3:3 Missing JS documentation comment.",
-  "file:///mod.ts:3:3 Missing explicit type.",
+  "file:///mod.ts:3:3 Missing return type.",
   "file:///mod.ts:4:3 Missing JS documentation comment.",
-  "file:///mod.ts:4:3 Missing explicit type."
+  "file:///mod.ts:4:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassExtends.txt
+++ b/tests/specs/ClassExtends.txt
@@ -5,6 +5,7 @@ export class Class extends Object {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassExtendsImplements.txt
+++ b/tests/specs/ClassExtendsImplements.txt
@@ -5,6 +5,7 @@ export class Class extends Object implements Iterator, Iterable {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassGenericExtendsImplements.txt
+++ b/tests/specs/ClassGenericExtendsImplements.txt
@@ -5,6 +5,7 @@ export class Class<A, B> extends Map<A, B> implements Iterator<A>, Iterable<B> {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassGetterAndSetter.txt
+++ b/tests/specs/ClassGetterAndSetter.txt
@@ -9,8 +9,9 @@ export class Class {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:3:3 Missing JS documentation comment.",
-  "file:///mod.ts:3:3 Missing explicit type."
+  "file:///mod.ts:3:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassImplements.txt
+++ b/tests/specs/ClassImplements.txt
@@ -5,6 +5,7 @@ export class Class implements Iterator {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassImplements2.txt
+++ b/tests/specs/ClassImplements2.txt
@@ -5,6 +5,7 @@ export class Class implements Iterator, Iterable {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassIndexSignature.txt
+++ b/tests/specs/ClassIndexSignature.txt
@@ -8,6 +8,7 @@ export class C {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassMethod.txt
+++ b/tests/specs/ClassMethod.txt
@@ -7,8 +7,9 @@ export class Class {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type."
+  "file:///mod.ts:2:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassMethodOverloads.txt
+++ b/tests/specs/ClassMethodOverloads.txt
@@ -11,6 +11,7 @@ export class A {
   "file:///mod.ts:2:7 Missing JS documentation comment.",
   "file:///mod.ts:3:7 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassOverridePropMethod.txt
+++ b/tests/specs/ClassOverridePropMethod.txt
@@ -10,6 +10,7 @@ export class C extends B {
   "file:///mod.ts:3:3 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassProperty.txt
+++ b/tests/specs/ClassProperty.txt
@@ -10,6 +10,7 @@ export class Class {
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:3:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassReadonlyIndexSignature.txt
+++ b/tests/specs/ClassReadonlyIndexSignature.txt
@@ -8,6 +8,7 @@ export class C {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassReadonlyProperty.txt
+++ b/tests/specs/ClassReadonlyProperty.txt
@@ -8,6 +8,7 @@ export class Class {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ClassStaticProperty.txt
+++ b/tests/specs/ClassStaticProperty.txt
@@ -8,6 +8,7 @@ export class Class {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ConstDeclaration.txt
+++ b/tests/specs/ConstDeclaration.txt
@@ -5,6 +5,7 @@ export const Const = 0;
 [
   "file:///mod.ts:1:14 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:14
 

--- a/tests/specs/CtorOverloads.txt
+++ b/tests/specs/CtorOverloads.txt
@@ -13,6 +13,7 @@ export class A {
   "file:///mod.ts:3:3 Missing JS documentation comment.",
   "file:///mod.ts:4:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/DeclareNamespace.txt
+++ b/tests/specs/DeclareNamespace.txt
@@ -18,6 +18,7 @@ declare namespace RootNs {
   "file:///mod.ts:3:19 Missing JS documentation comment.",
   "file:///mod.ts:7:7 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/DeclareNamespaceIgnore.txt
+++ b/tests/specs/DeclareNamespaceIgnore.txt
@@ -19,6 +19,7 @@ declare namespace RootNs {
 [
   "file:///mod.ts:3:19 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/DecoratorsJsdoc.txt
+++ b/tests/specs/DecoratorsJsdoc.txt
@@ -9,6 +9,7 @@ export class A {
 [
   "file:///mod.ts:4:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:3:1
 

--- a/tests/specs/DefaultExportsDeclaredEarlier.txt
+++ b/tests/specs/DefaultExportsDeclaredEarlier.txt
@@ -6,6 +6,7 @@ export default foo;
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/DocPrinterUnsupportedTag.txt
+++ b/tests/specs/DocPrinterUnsupportedTag.txt
@@ -9,8 +9,9 @@ export function noop() {
 # diagnostics
 [
   "file:///mod.ts:5:1 Missing JS documentation comment.",
-  "file:///mod.ts:5:1 Missing explicit type."
+  "file:///mod.ts:5:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:5:1
 

--- a/tests/specs/EnumDeclaration.txt
+++ b/tests/specs/EnumDeclaration.txt
@@ -5,6 +5,7 @@ export enum Enum {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/EnumMember.txt
+++ b/tests/specs/EnumMember.txt
@@ -9,6 +9,7 @@ export enum Enum {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportClass.txt
+++ b/tests/specs/ExportClass.txt
@@ -43,8 +43,9 @@ export class Foobar extends Fizz implements Buzz, Aldrin {
   "file:///mod.ts:10:5 Missing JS documentation comment.",
   "file:///mod.ts:11:5 Missing JS documentation comment.",
   "file:///mod.ts:31:5 Missing JS documentation comment.",
-  "file:///mod.ts:31:5 Missing explicit type."
+  "file:///mod.ts:31:5 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/ExportClassCtorProperties.txt
+++ b/tests/specs/ExportClassCtorProperties.txt
@@ -8,6 +8,7 @@ export class A {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportClassDecorators.txt
+++ b/tests/specs/ExportClassDecorators.txt
@@ -24,12 +24,13 @@ export class A {
   "file:///mod.ts:2:1 Missing JS documentation comment.",
   "file:///mod.ts:5:3 Missing JS documentation comment.",
   "file:///mod.ts:8:3 Missing JS documentation comment.",
-  "file:///mod.ts:8:3 Missing explicit type.",
+  "file:///mod.ts:8:3 Missing return type.",
   "file:///mod.ts:13:3 Missing JS documentation comment.",
-  "file:///mod.ts:13:3 Missing explicit type.",
+  "file:///mod.ts:13:3 Missing return type.",
   "file:///mod.ts:18:3 Missing JS documentation comment.",
-  "file:///mod.ts:18:3 Missing explicit type."
+  "file:///mod.ts:18:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/ExportClassIgnore.txt
+++ b/tests/specs/ExportClassIgnore.txt
@@ -43,6 +43,7 @@ export class Foobar extends Fizz implements Buzz, Aldrin {
   "file:///mod.ts:14:5 Missing JS documentation comment.",
   "file:///mod.ts:15:5 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/ExportClassObjectExtends.txt
+++ b/tests/specs/ExportClassObjectExtends.txt
@@ -9,6 +9,7 @@ export class Bar extends obj.Foo {}
   "file:///mod.ts:2:7 Type is not exported, but referenced by an exported type.",
   "file:///mod.ts:4:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:7
 

--- a/tests/specs/ExportConstBasic.txt
+++ b/tests/specs/ExportConstBasic.txt
@@ -31,6 +31,7 @@ export const tpl3 = `Value: ${num}`;
   "file:///mod.ts:17:14 Missing JS documentation comment.",
   "file:///mod.ts:18:14 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:14:14
 

--- a/tests/specs/ExportConstDestructured.txt
+++ b/tests/specs/ExportConstDestructured.txt
@@ -21,6 +21,7 @@ const c = { a: "a", b: 2 };
   "file:///mod.ts:16:20 Missing JS documentation comment.",
   "file:///mod.ts:16:26 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:6:7
 

--- a/tests/specs/ExportDeclarationMergedNamespace.txt
+++ b/tests/specs/ExportDeclarationMergedNamespace.txt
@@ -14,6 +14,7 @@ export { Namespace1 };
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:5:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportDefaultExpr.txt
+++ b/tests/specs/ExportDefaultExpr.txt
@@ -5,6 +5,7 @@ export default "foo";
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportDefaultFn.txt
+++ b/tests/specs/ExportDefaultFn.txt
@@ -10,8 +10,9 @@ export default function foo(a: number) {
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportFn2.txt
+++ b/tests/specs/ExportFn2.txt
@@ -12,6 +12,7 @@ export function foo([e,,f, ...g]: number[], { c, d: asdf, i = "asdf", ...rest}, 
   "file:///mod.ts:1:1 Type is not exported, but referenced by an exported type.",
   "file:///mod.ts:5:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:5:1
 

--- a/tests/specs/ExportInterface.txt
+++ b/tests/specs/ExportInterface.txt
@@ -18,6 +18,7 @@ export interface Reader extends Foo, Bar {
   "file:///mod.ts:1:1 Type is not exported, but referenced by an exported type.",
   "file:///mod.ts:3:1 Type is not exported, but referenced by an exported type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:3:1
 

--- a/tests/specs/ExportInterface2.txt
+++ b/tests/specs/ExportInterface2.txt
@@ -8,6 +8,7 @@ export interface TypedIface<T> {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:5 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportInterfaceAccessors.txt
+++ b/tests/specs/ExportInterfaceAccessors.txt
@@ -9,8 +9,9 @@ export interface Thing {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:3:3 Missing JS documentation comment.",
-  "file:///mod.ts:3:3 Missing explicit type."
+  "file:///mod.ts:3:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportLet.txt
+++ b/tests/specs/ExportLet.txt
@@ -17,6 +17,7 @@ export let tpl = `foobarbaz`;
   "file:///mod.ts:6:12 Missing JS documentation comment.",
   "file:///mod.ts:7:12 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:3:12
 

--- a/tests/specs/ExportNamespace.txt
+++ b/tests/specs/ExportNamespace.txt
@@ -24,6 +24,7 @@ export namespace RootNs.OtherNs {
   "file:///mod.ts:15:8 Missing JS documentation comment.",
   "file:///mod.ts:16:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/ExportNamespaceEnumSameName.txt
+++ b/tests/specs/ExportNamespaceEnumSameName.txt
@@ -16,6 +16,7 @@ export namespace RootNs {
   "file:///mod.ts:3:5 Missing JS documentation comment.",
   "file:///mod.ts:7:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportPrivate.txt
+++ b/tests/specs/ExportPrivate.txt
@@ -7,6 +7,7 @@ export { foo };
 [
   "file:///mod.ts:1:7 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:7
 

--- a/tests/specs/ExportTypeAliasLiteral.txt
+++ b/tests/specs/ExportTypeAliasLiteral.txt
@@ -11,6 +11,7 @@ export type A = {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportsAllWithPrivate.txt
+++ b/tests/specs/ExportsAllWithPrivate.txt
@@ -12,11 +12,12 @@ namespace H {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type.",
+  "file:///mod.ts:1:1 Missing return type.",
   "file:///mod.ts:3:1 Missing JS documentation comment.",
   "file:///mod.ts:5:1 Missing JS documentation comment.",
   "file:///mod.ts:7:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ExportsDeclaredEarlier.txt
+++ b/tests/specs/ExportsDeclaredEarlier.txt
@@ -10,6 +10,7 @@ export { hello, say, foo as bar };
   "file:///mod.ts:2:1 Missing JS documentation comment.",
   "file:///mod.ts:3:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:3:1
 

--- a/tests/specs/FunctionArrayDeconstruction.txt
+++ b/tests/specs/FunctionArrayDeconstruction.txt
@@ -4,8 +4,9 @@ export function f([a, b, ...c]) {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionAsync.txt
+++ b/tests/specs/FunctionAsync.txt
@@ -4,8 +4,9 @@ export async function a() {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionAsyncGenerator.txt
+++ b/tests/specs/FunctionAsyncGenerator.txt
@@ -4,8 +4,9 @@ export async function* ag() {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionDeclaration.txt
+++ b/tests/specs/FunctionDeclaration.txt
@@ -4,8 +4,9 @@ export function fun() {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionGenerator.txt
+++ b/tests/specs/FunctionGenerator.txt
@@ -4,8 +4,9 @@ export function* g() {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionGeneric.txt
+++ b/tests/specs/FunctionGeneric.txt
@@ -4,8 +4,9 @@ export function add<T>(a: T, b: T) { return a + b; }
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionObjectDeconstruction.txt
+++ b/tests/specs/FunctionObjectDeconstruction.txt
@@ -4,8 +4,9 @@ export function f({ a, b, ...c }) {}
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/FunctionOverloads.txt
+++ b/tests/specs/FunctionOverloads.txt
@@ -8,6 +8,7 @@ export function a(b: string | number): string | number {}
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/GenericInstantiatedWithTupleType.txt
+++ b/tests/specs/GenericInstantiatedWithTupleType.txt
@@ -7,6 +7,7 @@ export function f(): Generic<[string, number]> { return {}; }
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/ImportEquals.txt
+++ b/tests/specs/ImportEquals.txt
@@ -12,6 +12,7 @@ export { Options };
 [
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:3
 

--- a/tests/specs/ImportTypes.txt
+++ b/tests/specs/ImportTypes.txt
@@ -6,8 +6,9 @@ export function adopt<T>(p: import("./module.ts").Pet<T>) {
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InferObjectLiteral.txt
+++ b/tests/specs/InferObjectLiteral.txt
@@ -22,6 +22,7 @@ const s: symbol = Symbol.for("s");
 [
   "file:///mod.ts:4:18 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:4:18
 

--- a/tests/specs/InferSimpleTsArrTypes.txt
+++ b/tests/specs/InferSimpleTsArrTypes.txt
@@ -17,6 +17,7 @@ export const a = [1];
   "file:///mod.ts:6:20 Missing JS documentation comment.",
   "file:///mod.ts:7:20 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:14
 

--- a/tests/specs/InferSimpleTsTypes.txt
+++ b/tests/specs/InferSimpleTsTypes.txt
@@ -33,6 +33,7 @@ export const s3 = "VGhpcyBpcyBhIHJlYWxseSBsb25nIHN0cmluZyB0byB0cnkgdG8gZmluZCBvd
   "file:///mod.ts:14:14 Missing JS documentation comment.",
   "file:///mod.ts:15:14 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:3:14
 

--- a/tests/specs/InferTsTypes.txt
+++ b/tests/specs/InferTsTypes.txt
@@ -15,6 +15,7 @@ export let s = "hello";
   "file:///mod.ts:5:16 Missing JS documentation comment.",
   "file:///mod.ts:6:16 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:3:16
 

--- a/tests/specs/InferTypes.txt
+++ b/tests/specs/InferTypes.txt
@@ -5,6 +5,7 @@ export type Flatten<T> = T extends Array<infer U> ? U : T;
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceConstruct.txt
+++ b/tests/specs/InterfaceConstruct.txt
@@ -7,8 +7,9 @@ export interface I {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type."
+  "file:///mod.ts:2:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceDeclaration.txt
+++ b/tests/specs/InterfaceDeclaration.txt
@@ -5,6 +5,7 @@ export interface Interface {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceExtends.txt
+++ b/tests/specs/InterfaceExtends.txt
@@ -5,6 +5,7 @@ export interface Interface extends Iterator {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceExtends2.txt
+++ b/tests/specs/InterfaceExtends2.txt
@@ -5,6 +5,7 @@ export interface Interface extends Iterator, Iterable {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceGeneric.txt
+++ b/tests/specs/InterfaceGeneric.txt
@@ -5,6 +5,7 @@ export interface Interface<T> {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceGenericExtends.txt
+++ b/tests/specs/InterfaceGenericExtends.txt
@@ -5,6 +5,7 @@ export interface Interface<V> extends Iterable<V> {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceIndexSignature.txt
+++ b/tests/specs/InterfaceIndexSignature.txt
@@ -8,6 +8,7 @@ export interface Interface {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceMethod.txt
+++ b/tests/specs/InterfaceMethod.txt
@@ -9,12 +9,13 @@ export interface I {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment.",
-  "file:///mod.ts:2:3 Missing explicit type.",
+  "file:///mod.ts:2:3 Missing return type.",
   "file:///mod.ts:3:3 Missing JS documentation comment.",
-  "file:///mod.ts:3:3 Missing explicit type.",
+  "file:///mod.ts:3:3 Missing return type.",
   "file:///mod.ts:4:3 Missing JS documentation comment.",
-  "file:///mod.ts:4:3 Missing explicit type."
+  "file:///mod.ts:4:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceNumberLiteralProperty.txt
+++ b/tests/specs/InterfaceNumberLiteralProperty.txt
@@ -10,6 +10,7 @@ export interface I {
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:3:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceProperty.txt
+++ b/tests/specs/InterfaceProperty.txt
@@ -14,6 +14,7 @@ export interface I {
   "file:///mod.ts:4:3 Missing JS documentation comment.",
   "file:///mod.ts:5:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceReadonlyIndexSignature.txt
+++ b/tests/specs/InterfaceReadonlyIndexSignature.txt
@@ -8,6 +8,7 @@ export interface Interface {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InterfaceStringLiteralProperty.txt
+++ b/tests/specs/InterfaceStringLiteralProperty.txt
@@ -10,6 +10,7 @@ export interface I {
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:3:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/InternalTag.txt
+++ b/tests/specs/InternalTag.txt
@@ -1,33 +1,48 @@
-{ "private": true }
 # mod.ts
-export class Class {
-  private property = "";
+// the internal tag will suppress diagnostics
+
+/** @internal */
+type PrivateType = string;
+
+/** @internal */
+export class MyClass {
+  test: string;
 }
 
 # diagnostics
 [
-  "file:///mod.ts:1:1 Missing JS documentation comment."
+  "file:///mod.ts:8:3 Missing JS documentation comment."
 ]
 
 # output.txt
-Defined in file:///mod.ts:1:1
+Defined in file:///mod.ts:7:1
 
-class Class
+class MyClass
 
-  private property: string
+  @internal
+
+  test: string
 
 
 # output.json
 [
   {
     "kind": "class",
-    "name": "Class",
+    "name": "MyClass",
     "location": {
       "filename": "file:///mod.ts",
-      "line": 1,
+      "line": 7,
       "col": 0
     },
     "declarationKind": "export",
+    "jsDoc": {
+      "tags": [
+        {
+          "kind": "unsupported",
+          "value": "@internal"
+        }
+      ]
+    },
     "classDef": {
       "isAbstract": false,
       "constructors": [],
@@ -39,14 +54,14 @@ class Class
             "keyword": "string"
           },
           "readonly": false,
-          "accessibility": "private",
+          "accessibility": null,
           "optional": false,
           "isAbstract": false,
           "isStatic": false,
-          "name": "property",
+          "name": "test",
           "location": {
             "filename": "file:///mod.ts",
-            "line": 2,
+            "line": 8,
             "col": 2
           }
         }

--- a/tests/specs/InternalTag.txt
+++ b/tests/specs/InternalTag.txt
@@ -6,13 +6,26 @@ type PrivateType = string;
 
 /** @internal */
 export class MyClass {
-  test: string;
+  // will ignore missing jsdocs on all these members
+  test;
+
+  method() {
+    return Math.random();
+  }
+
+  privateTypeUse: PrivateType;
 }
 
-# diagnostics
-[
-  "file:///mod.ts:8:3 Missing JS documentation comment."
-]
+/** Test **/
+export class Other {
+  /** @internal **/
+  test;
+
+  /** @internal **/
+  method() {
+    return Math.random();
+  }
+}
 
 # output.txt
 Defined in file:///mod.ts:7:1
@@ -21,7 +34,27 @@ class MyClass
 
   @internal
 
-  test: string
+  test
+  privateTypeUse: PrivateType
+  method()
+
+Defined in file:///mod.ts:19:1
+
+class Other
+  Test *
+
+  test
+
+    @internal *
+  method()
+
+    @internal *
+
+Defined in file:///mod.ts:4:1
+
+private type PrivateType = string
+
+  @internal
 
 
 # output.json
@@ -48,11 +81,7 @@ class MyClass
       "constructors": [],
       "properties": [
         {
-          "tsType": {
-            "repr": "string",
-            "kind": "keyword",
-            "keyword": "string"
-          },
+          "tsType": null,
           "readonly": false,
           "accessibility": null,
           "optional": false,
@@ -61,17 +90,163 @@ class MyClass
           "name": "test",
           "location": {
             "filename": "file:///mod.ts",
-            "line": 8,
+            "line": 9,
+            "col": 2
+          }
+        },
+        {
+          "tsType": {
+            "repr": "PrivateType",
+            "kind": "typeRef",
+            "typeRef": {
+              "typeParams": null,
+              "typeName": "PrivateType"
+            }
+          },
+          "readonly": false,
+          "accessibility": null,
+          "optional": false,
+          "isAbstract": false,
+          "isStatic": false,
+          "name": "privateTypeUse",
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 15,
             "col": 2
           }
         }
       ],
       "indexSignatures": [],
-      "methods": [],
+      "methods": [
+        {
+          "accessibility": null,
+          "optional": false,
+          "isAbstract": false,
+          "isStatic": false,
+          "name": "method",
+          "kind": "method",
+          "functionDef": {
+            "params": [],
+            "returnType": null,
+            "hasBody": true,
+            "isAsync": false,
+            "isGenerator": false,
+            "typeParams": []
+          },
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 11,
+            "col": 2
+          }
+        }
+      ],
       "extends": null,
       "implements": [],
       "typeParams": [],
       "superTypeParams": []
+    }
+  },
+  {
+    "kind": "class",
+    "name": "Other",
+    "location": {
+      "filename": "file:///mod.ts",
+      "line": 19,
+      "col": 0
+    },
+    "declarationKind": "export",
+    "jsDoc": {
+      "doc": "Test *"
+    },
+    "classDef": {
+      "isAbstract": false,
+      "constructors": [],
+      "properties": [
+        {
+          "jsDoc": {
+            "tags": [
+              {
+                "kind": "unsupported",
+                "value": "@internal *"
+              }
+            ]
+          },
+          "tsType": null,
+          "readonly": false,
+          "accessibility": null,
+          "optional": false,
+          "isAbstract": false,
+          "isStatic": false,
+          "name": "test",
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 21,
+            "col": 2
+          }
+        }
+      ],
+      "indexSignatures": [],
+      "methods": [
+        {
+          "jsDoc": {
+            "tags": [
+              {
+                "kind": "unsupported",
+                "value": "@internal *"
+              }
+            ]
+          },
+          "accessibility": null,
+          "optional": false,
+          "isAbstract": false,
+          "isStatic": false,
+          "name": "method",
+          "kind": "method",
+          "functionDef": {
+            "params": [],
+            "returnType": null,
+            "hasBody": true,
+            "isAsync": false,
+            "isGenerator": false,
+            "typeParams": []
+          },
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 24,
+            "col": 2
+          }
+        }
+      ],
+      "extends": null,
+      "implements": [],
+      "typeParams": [],
+      "superTypeParams": []
+    }
+  },
+  {
+    "kind": "typeAlias",
+    "name": "PrivateType",
+    "location": {
+      "filename": "file:///mod.ts",
+      "line": 4,
+      "col": 0
+    },
+    "declarationKind": "private",
+    "jsDoc": {
+      "tags": [
+        {
+          "kind": "unsupported",
+          "value": "@internal"
+        }
+      ]
+    },
+    "typeAliasDef": {
+      "tsType": {
+        "repr": "string",
+        "kind": "keyword",
+        "keyword": "string"
+      },
+      "typeParams": []
     }
   }
 ]

--- a/tests/specs/InternalTag.txt
+++ b/tests/specs/InternalTag.txt
@@ -16,12 +16,12 @@ export class MyClass {
   privateTypeUse: PrivateType;
 }
 
-/** Test **/
+/** Test */
 export class Other {
-  /** @internal **/
+  /** @internal */
   test;
 
-  /** @internal **/
+  /** @internal */
   method() {
     return Math.random();
   }
@@ -41,14 +41,14 @@ class MyClass
 Defined in file:///mod.ts:19:1
 
 class Other
-  Test *
+  Test
 
   test
 
-    @internal *
+    @internal
   method()
 
-    @internal *
+    @internal
 
 Defined in file:///mod.ts:4:1
 
@@ -156,7 +156,7 @@ private type PrivateType = string
     },
     "declarationKind": "export",
     "jsDoc": {
-      "doc": "Test *"
+      "doc": "Test"
     },
     "classDef": {
       "isAbstract": false,
@@ -167,7 +167,7 @@ private type PrivateType = string
             "tags": [
               {
                 "kind": "unsupported",
-                "value": "@internal *"
+                "value": "@internal"
               }
             ]
           },
@@ -192,7 +192,7 @@ private type PrivateType = string
             "tags": [
               {
                 "kind": "unsupported",
-                "value": "@internal *"
+                "value": "@internal"
               }
             ]
           },

--- a/tests/specs/Jsdoc.txt
+++ b/tests/specs/Jsdoc.txt
@@ -20,8 +20,9 @@ export function C() {}
 
 # diagnostics
 [
-  "file:///mod.ts:18:1 Missing explicit type."
+  "file:///mod.ts:18:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:18:1
 

--- a/tests/specs/JsdocTags.txt
+++ b/tests/specs/JsdocTags.txt
@@ -11,8 +11,9 @@ export function a(b, c, d) {}
 
 # diagnostics
 [
-  "file:///mod.ts:9:1 Missing explicit type."
+  "file:///mod.ts:9:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:9:1
 

--- a/tests/specs/MappedTypes.txt
+++ b/tests/specs/MappedTypes.txt
@@ -7,6 +7,7 @@ export type MappedTypeWithNewProperties<Type> = {
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/NamespaceDeclaration.txt
+++ b/tests/specs/NamespaceDeclaration.txt
@@ -5,6 +5,7 @@ export namespace Namespace {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/NamespaceDetails.txt
+++ b/tests/specs/NamespaceDetails.txt
@@ -17,8 +17,9 @@ export namespace Namespace {
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:7:3 Missing explicit type."
+  "file:///mod.ts:7:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/NamespaceFnOverloads.txt
+++ b/tests/specs/NamespaceFnOverloads.txt
@@ -11,6 +11,7 @@ export namespace Namespace {
   "file:///mod.ts:2:3 Missing JS documentation comment.",
   "file:///mod.ts:3:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/NoAmbientInModule.txt
+++ b/tests/specs/NoAmbientInModule.txt
@@ -5,8 +5,9 @@ export function bar() {};
 # diagnostics
 [
   "file:///mod.ts:2:1 Missing JS documentation comment.",
-  "file:///mod.ts:2:1 Missing explicit type."
+  "file:///mod.ts:2:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/NonImplementedRenamedExportsDeclaredEarlier.txt
+++ b/tests/specs/NonImplementedRenamedExportsDeclaredEarlier.txt
@@ -6,6 +6,7 @@ declare function foo(): void;
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/OptionalReturnType.txt
+++ b/tests/specs/OptionalReturnType.txt
@@ -6,8 +6,9 @@ export function foo(a: number) {
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/Overloads.txt
+++ b/tests/specs/Overloads.txt
@@ -10,6 +10,7 @@ export function a(b: string | number): string | number {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/ReexportExistingExport.txt
+++ b/tests/specs/ReexportExistingExport.txt
@@ -6,6 +6,7 @@ export { foo as bar };
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/StructuredJsdoc.txt
+++ b/tests/specs/StructuredJsdoc.txt
@@ -24,8 +24,9 @@ export class A {
 [
   "file:///mod.ts:4:3 Missing JS documentation comment.",
   "file:///mod.ts:19:3 Missing JS documentation comment.",
-  "file:///mod.ts:19:3 Missing explicit type."
+  "file:///mod.ts:19:3 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:2:1
 

--- a/tests/specs/TsLitTypes.txt
+++ b/tests/specs/TsLitTypes.txt
@@ -13,6 +13,7 @@ export type numLit = 5;
   "file:///mod.ts:4:1 Missing JS documentation comment.",
   "file:///mod.ts:5:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TsTemplateWithArgs.txt
+++ b/tests/specs/TsTemplateWithArgs.txt
@@ -5,6 +5,7 @@ export const tpl: `test${number}` = `test1`;
 [
   "file:///mod.ts:1:14 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:14
 

--- a/tests/specs/TsTypeAssertion.txt
+++ b/tests/specs/TsTypeAssertion.txt
@@ -5,6 +5,7 @@ export function foo(bar: any): asserts bar {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TsTypePredicate1.txt
+++ b/tests/specs/TsTypePredicate1.txt
@@ -5,6 +5,7 @@ export function foo(bar: A | B): bar is A {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TsTypePredicate2.txt
+++ b/tests/specs/TsTypePredicate2.txt
@@ -5,6 +5,7 @@ export function foo(bar: A | B): asserts bar is B {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TsTypePredicate3.txt
+++ b/tests/specs/TsTypePredicate3.txt
@@ -8,6 +8,7 @@ export class C {
   "file:///mod.ts:1:1 Missing JS documentation comment.",
   "file:///mod.ts:2:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TsUserDefinedTypeGuards.txt
+++ b/tests/specs/TsUserDefinedTypeGuards.txt
@@ -24,6 +24,7 @@ export class C {
   "file:///mod.ts:11:1 Missing JS documentation comment.",
   "file:///mod.ts:12:3 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:4:1
 

--- a/tests/specs/TypeAlias.txt
+++ b/tests/specs/TypeAlias.txt
@@ -5,6 +5,7 @@ export type A = number
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeAliasInferType.txt
+++ b/tests/specs/TypeAliasInferType.txt
@@ -5,6 +5,7 @@ export type Flatten<T> = T extends Array<infer U> ? U : T;
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeGenericAlias.txt
+++ b/tests/specs/TypeGenericAlias.txt
@@ -5,6 +5,7 @@ export type A<T> = T
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeImportType.txt
+++ b/tests/specs/TypeImportType.txt
@@ -4,8 +4,9 @@ export function adopt<T>(p: import("./module.ts").Pet<T>) { }
 # diagnostics
 [
   "file:///mod.ts:1:1 Missing JS documentation comment.",
-  "file:///mod.ts:1:1 Missing explicit type."
+  "file:///mod.ts:1:1 Missing return type."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeLiteralDeclaration.txt
+++ b/tests/specs/TypeLiteralDeclaration.txt
@@ -5,6 +5,7 @@ export type T = {}
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeLiteralIndexSignature.txt
+++ b/tests/specs/TypeLiteralIndexSignature.txt
@@ -5,6 +5,7 @@ export type T = { [key: string]: number; }
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeLiteralMappedType.txt
+++ b/tests/specs/TypeLiteralMappedType.txt
@@ -5,6 +5,7 @@ export type T<Type> = { readonly [P in keyof Type as NewType]: Type[P]; }
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 

--- a/tests/specs/TypeLiteralReadonlyIndexSignature.txt
+++ b/tests/specs/TypeLiteralReadonlyIndexSignature.txt
@@ -5,6 +5,7 @@ export type T = { readonly [key: string]: number; }
 [
   "file:///mod.ts:1:1 Missing JS documentation comment."
 ]
+
 # output.txt
 Defined in file:///mod.ts:1:1
 


### PR DESCRIPTION
This supresses diagnostics on nodes marked with `@internal`. This is something we can change in the future, but I think it makes sense.