### PR TITLE
fix: better @ignore jsdoc handling

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -5,7 +5,7 @@ use crate::js_doc::JsDocTag;
 use crate::node::DeclarationKind;
 use crate::node::DocNode;
 use crate::node::NamespaceDef;
-use crate::swc_util::js_doc_for_range;
+use crate::swc_util::js_doc_for_range_include_ignore;
 use crate::ts_type::TsTypeDef;
 use crate::variable::VariableDef;
 use crate::DocNodeKind;
@@ -413,12 +413,10 @@ fn decl_has_internal_js_doc_tag(
   let Some(module) = module.esm() else {
     return false;
   };
-  let Some(js_doc) = js_doc_for_range(module.source(), &decl.range) else {
-    return false;
-  };
+  let js_doc = js_doc_for_range_include_ignore(module.source(), &decl.range);
   has_internal_js_doc_tag(&js_doc)
 }
 
 fn has_internal_js_doc_tag(js_doc: &JsDoc) -> bool {
-  js_doc.tags.iter().any(|t| matches!(t, JsDocTag::Unsupported { value } if value == "@internal" || value.starts_with("@internal ")))
+  js_doc.tags.iter().any(|t| matches!(t, JsDocTag::Ignore) || matches!(t, JsDocTag::Unsupported { value } if value == "@internal" || value.starts_with("@internal ")))
 }

--- a/tests/specs/InternalTag.txt
+++ b/tests/specs/InternalTag.txt
@@ -27,6 +27,18 @@ export class Other {
   }
 }
 
+// also should work with @ignore
+
+/** @ignore */
+type OtherPrivateType = string;
+
+export type Test = OtherPrivateType;
+
+# diagnostics
+[
+  "file:///mod.ts:34:1 Missing JS documentation comment."
+]
+
 # output.txt
 Defined in file:///mod.ts:7:1
 
@@ -55,6 +67,10 @@ Defined in file:///mod.ts:4:1
 private type PrivateType = string
 
   @internal
+
+Defined in file:///mod.ts:34:1
+
+type Test = OtherPrivateType
 
 
 # output.json
@@ -221,6 +237,27 @@ private type PrivateType = string
       "implements": [],
       "typeParams": [],
       "superTypeParams": []
+    }
+  },
+  {
+    "kind": "typeAlias",
+    "name": "Test",
+    "location": {
+      "filename": "file:///mod.ts",
+      "line": 34,
+      "col": 0
+    },
+    "declarationKind": "export",
+    "typeAliasDef": {
+      "tsType": {
+        "repr": "OtherPrivateType",
+        "kind": "typeRef",
+        "typeRef": {
+          "typeParams": null,
+          "typeName": "OtherPrivateType"
+        }
+      },
+      "typeParams": []
     }
   },
   {

--- a/tests/specs/ModuleDocsIgnoreNoModuleTag.txt
+++ b/tests/specs/ModuleDocsIgnoreNoModuleTag.txt
@@ -1,0 +1,45 @@
+# mod.ts
+/* a non-jsdoc comment */
+
+/**
+ * A leading JSDoc comment
+ * @ignore
+ */
+
+/** One associated with a class */
+export class A {}
+# output.txt
+Defined in file:///mod.ts:9:1
+
+class A
+  One associated with a class
+
+
+
+# output.json
+[
+  {
+    "kind": "class",
+    "name": "A",
+    "location": {
+      "filename": "file:///mod.ts",
+      "line": 9,
+      "col": 0
+    },
+    "declarationKind": "export",
+    "jsDoc": {
+      "doc": "One associated with a class"
+    },
+    "classDef": {
+      "isAbstract": false,
+      "constructors": [],
+      "properties": [],
+      "indexSignatures": [],
+      "methods": [],
+      "extends": null,
+      "implements": [],
+      "typeParams": [],
+      "superTypeParams": []
+    }
+  }
+]


### PR DESCRIPTION
Fixes two issues:

1. `@ignore` tags are respected for the "non-exported" type diagnostics.
2. The `@ignore` tag does not ignore the entire module unless the `@module` tag is also in the jsdoc. I discovered this by accident.