### PR TITLE
fix: issue discovering re-exports of re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ checksum = "41b319d1b62ffbd002e057f36bebd1f42b9f97927c9577461d855f3513c4289f"
 
 [[package]]
 name = "deno_ast"
-version = "0.31.1"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e1590ff56dcebd6087a6615f1adb7dd93b9e2e808959eb2aab53dd0e7750b7"
+checksum = "7b74b2504e2428e7ef9ca491359d5f98ab46406cc71d93d0008b7823d5d35a6d"
 dependencies = [
  "deno_media_type",
  "dprint-swc-ext",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64069da5890ef2d9133199a62d712500529f079dc1bd3a3fe488e64e433ac8ea"
+checksum = "1bd6700dd3cec2a7763760168c952cc632246a1ae0fc52d6f297e2802b994e69"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -851,17 +851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +894,19 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hstr"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de90d3db62411eb62eddabe402d706ac4970f7ac8d088c05f11069cad9be9857"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "smallvec",
+]
 
 [[package]]
 name = "html-escape"
@@ -1227,20 +1229,19 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
  "phf_shared",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1248,23 +1249,22 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -1347,18 +1347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,12 +1355,6 @@ dependencies = [
  "diff",
  "yansi",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -1416,18 +1398,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -1436,9 +1406,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "rayon"
@@ -1672,12 +1639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,32 +1656,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "string_cache"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "string_enum"
@@ -1749,23 +1684,21 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf7a12229f0c0efb654a6a0f8cbfd94fbd320a57c764857a82d8abe9342b450"
+checksum = "b8a9e1b6d97f27b6abe5571f8fe3bdbd2fa987299fc2126450c7cde6214896ef"
 dependencies = [
+ "hstr",
  "once_cell",
  "rustc-hash",
  "serde",
- "string_cache",
- "string_cache_codegen",
- "triomphe",
 ]
 
 [[package]]
 name = "swc_common"
-version = "0.33.0"
+version = "0.33.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490e199e25d2aa3fbef675524fa81408651f4e7178b51110470ddd1b3e3bbe75"
+checksum = "5ccb656cd57c93614e4e8b33a60e75ca095383565c1a8d2bbe6a1103942831e0"
 dependencies = [
  "ast_node",
  "better_scoped_tls",
@@ -1778,7 +1711,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "siphasher",
- "string_cache",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
@@ -1789,13 +1721,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.110.0"
+version = "0.110.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbbf9918976a7e7fbdb4f76fe659d08e291a8b56b524b424183fc67d1189679"
+checksum = "2c3d416121da2d56bcbd1b1623725a68890af4552fef0c6d1e4bfa92776ccd6a"
 dependencies = [
  "bitflags 2.4.1",
  "is-macro",
  "num-bigint",
+ "phf",
  "scoped-tls",
  "serde",
  "string_enum",
@@ -1806,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_dep_graph"
-version = "0.113.3"
+version = "0.113.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3281df0c205727acf3584339533f093706205c9996e04964825625c932672db"
+checksum = "59fc6ac1a84afe910182dcda33d70a16545e6058529d51afb63bd6be8764370f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1818,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.45.0"
+version = "0.45.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fe06d942fe20a5a81cc14f4a53e64a5efdc851fa895a869224b2d41df73276"
+checksum = "31cf7549feec3698d0110a0a71ae547f31ae272dc92db3285ce126d6dcbdadf3"
 dependencies = [
  "anyhow",
  "pathdiff",
@@ -1831,13 +1764,15 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.141.3"
+version = "0.141.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a23445c5da841d4a5859b4e3a9cee0eb7c09a7b6fb0c0cc7eda2616b1204b12"
+checksum = "9cc89c175ed17c7f795fb18cf778a5745ecd794ad19c4662f85843d7571957a8"
 dependencies = [
  "either",
+ "new_debug_unreachable",
  "num-bigint",
  "num-traits",
+ "phf",
  "serde",
  "smallvec",
  "smartstring",
@@ -1851,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.134.8"
+version = "0.134.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a47ed8caf6d1c435e9e00bde780b1d449a2050b2689ff109fadeb30e3ffdefd"
+checksum = "d8110b783faee399cbd749fb35b832551b2b60d034593f1fbadd7af85cb157c1"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.4.1",
@@ -1874,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.124.7"
+version = "0.124.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd601a7d7088a95b93afde1dfcfdbf12fe2654a407629446ab42c758a47ba293"
+checksum = "d5d9434862c93aadda0b539847a5fdb82624472deed788333b35caf281773931"
 dependencies = [
  "indexmap 1.9.3",
  "num_cpus",
@@ -1892,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.96.0"
+version = "0.96.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47081acd84cdb2d49d6340ed3204e17738b444da10a3e1dd1eb3d7c8e4d47091"
+checksum = "ba962f0becf83bab12a17365dface5a4f636c9e1743d479e292b96910a753743"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2172,16 +2107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "triomphe"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee8098afad3fb0c54a9007aab6804558410503ad676d4633f9c2559a00ac0f"
-dependencies = [
- "serde",
- "stable_deref_trait",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ required-features = ["html"]
 [dependencies]
 anyhow = "1.0.58"
 cfg-if = "1.0.0"
-deno_ast = "0.31.0"
-deno_graph = { version = "0.60.0", features = ["symbols"] }
+deno_ast = "0.31.5"
+deno_graph = { version = "0.61.0", features = ["symbols"] }
 indexmap = "2.0.2"
 futures = "0.3.26"
 import_map = "0.15.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -233,6 +233,7 @@ impl<'a> DocParser<'a> {
         let mut flattened_docs = Vec::new();
         let exports = module_info.exports(&self.root_symbol);
         for (export_name, export) in exports.resolved {
+          let export = export.as_resolved_export();
           let export_symbol = export.module.symbol(export.symbol_id).unwrap();
           let definitions = self
             .root_symbol
@@ -932,6 +933,7 @@ impl<'a> DocParser<'a> {
     let mut handled_symbols = HashSet::new();
     let exports = module_info.exports(&self.root_symbol);
     for (export_name, export) in &exports.resolved {
+      let export = export.as_resolved_export();
       handled_symbols.insert(UniqueSymbolId::new(
         export.module.module_id(),
         export.symbol_id,
@@ -1043,7 +1045,7 @@ impl<'a> DocParser<'a> {
 
       for dep in &decl_with_deps.deps {
         let dep_module =
-          self.root_symbol.get_module_from_id(dep.module_id).unwrap();
+          self.root_symbol.module_from_id(dep.module_id).unwrap();
         let dep_symbol = dep_module.symbol(dep.symbol_id).unwrap();
         diagnostics.add_private_type_in_public(
           doc_module_info,

--- a/src/util/symbol.rs
+++ b/src/util/symbol.rs
@@ -13,7 +13,7 @@ pub fn get_module_info<'a>(
   root_symbol: &'a deno_graph::symbols::RootSymbol,
   specifier: &ModuleSpecifier,
 ) -> Result<ModuleInfoRef<'a>, DocError> {
-  match root_symbol.get_module_from_specifier(specifier) {
+  match root_symbol.module_from_specifier(specifier) {
     Some(symbol) => Ok(symbol),
     None => Err(DocError::Resolve(format!(
       "Could not find module in graph: {}",

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -79,9 +79,8 @@ impl SymbolVisibility {
     let mut pending_symbol_ids =
       root_exported_ids.keys().copied().collect::<Vec<_>>();
     while let Some(original_id) = pending_symbol_ids.pop() {
-      let module_info = root_symbol
-        .get_module_from_id(original_id.module_id)
-        .unwrap();
+      let module_info =
+        root_symbol.module_from_id(original_id.module_id).unwrap();
       let symbol = module_info.symbol(original_id.symbol_id).unwrap();
       let decl_deps = symbol
         .decls()
@@ -194,6 +193,7 @@ fn analyze_root_exported_ids(
       let module_info = get_module_info(root_symbol, module.specifier())?;
       let exports = module_info.exports(root_symbol);
       for (_name, export) in &exports.resolved {
+        let export = export.as_resolved_export();
         let symbol = export.module.symbol(export.symbol_id).unwrap();
         let definitions = root_symbol.go_to_definitions(export.module, symbol);
         for definition in definitions {

--- a/tests/specs/PrivateTypeOtherModule.txt
+++ b/tests/specs/PrivateTypeOtherModule.txt
@@ -3,6 +3,7 @@ import { MyNamespace, YesDiagnostic2 } from "./diagnostic.ts";
 
 export class MyClass extends YesDiagnostic2 {
   prop: MyNamespace.YesDiagnostic;
+  other: Uint8Array;
 }
 
 # diagnostic.ts
@@ -20,7 +21,8 @@ export class YesDiagnostic2 {}
   "file:///mod.ts:4:3 Type 'MyClass.prototype.prop' references type 'MyNamespace' (file:///diagnostic.ts:3:1) which is not exported from a root module.",
   "file:///mod.ts:4:3 Type 'MyClass.prototype.prop' references type 'MyNamespace.YesDiagnostic' (file:///diagnostic.ts:4:3) which is not exported from a root module.",
   "file:///mod.ts:3:1 Missing JSDoc comment.",
-  "file:///mod.ts:4:3 Missing JSDoc comment."
+  "file:///mod.ts:4:3 Missing JSDoc comment.",
+  "file:///mod.ts:5:3 Missing JSDoc comment."
 ]
 
 # output.txt
@@ -29,6 +31,7 @@ Defined in file:///mod.ts:3:1
 class MyClass extends YesDiagnostic2
 
   prop: MyNamespace.YesDiagnostic
+  other: Uint8Array
 
 Defined in file:///mod.ts:1:1
 
@@ -70,6 +73,27 @@ Defined in file:///mod.ts:1:1
           "location": {
             "filename": "file:///mod.ts",
             "line": 4,
+            "col": 2
+          }
+        },
+        {
+          "tsType": {
+            "repr": "Uint8Array",
+            "kind": "typeRef",
+            "typeRef": {
+              "typeParams": null,
+              "typeName": "Uint8Array"
+            }
+          },
+          "readonly": false,
+          "accessibility": null,
+          "optional": false,
+          "isAbstract": false,
+          "isStatic": false,
+          "name": "other",
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 5,
             "col": 2
           }
         }

--- a/tests/specs/ReExportAll.txt
+++ b/tests/specs/ReExportAll.txt
@@ -1,0 +1,78 @@
+# a.ts
+const test1: string = "";
+const test2: number = 3, test3: number = 3;
+const test4: number;
+const test5: number;
+
+export { test1, test2, test3 };
+export { test4, test5 };
+
+# b.ts
+export class Test {}
+
+# c.ts
+export * from "./a.ts";
+export { Test } from "./b.ts";
+
+# mod.ts
+export { Test, test1 } from "./c.ts";
+
+# diagnostics
+[
+  "file:///b.ts:1:1 Missing JSDoc comment.",
+  "file:///a.ts:1:7 Missing JSDoc comment."
+]
+
+# output.txt
+Defined in file:///a.ts:1:7
+
+const test1: string
+
+Defined in file:///b.ts:1:1
+
+class Test
+
+
+
+# output.json
+[
+  {
+    "kind": "class",
+    "name": "Test",
+    "location": {
+      "filename": "file:///b.ts",
+      "line": 1,
+      "col": 0
+    },
+    "declarationKind": "export",
+    "classDef": {
+      "isAbstract": false,
+      "constructors": [],
+      "properties": [],
+      "indexSignatures": [],
+      "methods": [],
+      "extends": null,
+      "implements": [],
+      "typeParams": [],
+      "superTypeParams": []
+    }
+  },
+  {
+    "kind": "variable",
+    "name": "test1",
+    "location": {
+      "filename": "file:///a.ts",
+      "line": 1,
+      "col": 6
+    },
+    "declarationKind": "export",
+    "variableDef": {
+      "tsType": {
+        "repr": "string",
+        "kind": "keyword",
+        "keyword": "string"
+      },
+      "kind": "const"
+    }
+  }
+]


### PR DESCRIPTION
I recently introduced a bug to deno_doc related to discovering re-exports. We didn't have a test so it wasn't caught.