### PR TITLE
fix: ignore empty return stmts when determining if return type necessary

### DIFF
--- a/tests/specs/FunctionAsync.txt
+++ b/tests/specs/FunctionAsync.txt
@@ -1,5 +1,7 @@
 # mod.ts
-export async function a() {}
+export async function a() {
+  return;
+}
 
 # diagnostics
 [


### PR DESCRIPTION
For https://github.com/denoland/deno/issues/21403