### PR TITLE
fix: actually support serde::Deserialize on DocNode

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -53,13 +53,13 @@ cfg_if! {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassConstructorParamDef {
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub accessibility: Option<deno_ast::swc::ast::Accessibility>,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub is_override: bool,
   #[serde(flatten)]
   pub param: ParamDef,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub readonly: bool,
 }
 
@@ -80,12 +80,12 @@ impl Display for ClassConstructorParamDef {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassConstructorDef {
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub accessibility: Option<deno_ast::swc::ast::Accessibility>,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub is_optional: bool,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub has_body: bool,
   pub name: String,
   pub params: Vec<ClassConstructorParamDef>,
@@ -108,17 +108,17 @@ impl Display for ClassConstructorDef {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassPropertyDef {
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub ts_type: Option<TsTypeDef>,
   pub readonly: bool,
   pub accessibility: Option<deno_ast::swc::ast::Accessibility>,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub decorators: Vec<DecoratorDef>,
   pub optional: bool,
   pub is_abstract: bool,
   pub is_static: bool,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub is_override: bool,
   pub name: String,
   pub location: Location,
@@ -163,7 +163,7 @@ impl Display for ClassPropertyDef {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassIndexSignatureDef {
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub readonly: bool,
   pub params: Vec<ParamDef>,
@@ -190,13 +190,13 @@ impl Display for ClassIndexSignatureDef {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ClassMethodDef {
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub accessibility: Option<deno_ast::swc::ast::Accessibility>,
   pub optional: bool,
   pub is_abstract: bool,
   pub is_static: bool,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub is_override: bool,
   pub name: String,
   pub kind: deno_ast::swc::ast::MethodKind,
@@ -252,7 +252,7 @@ pub struct ClassDef {
   pub implements: Vec<TsTypeDef>,
   pub type_params: Vec<TsTypeParamDef>,
   pub super_type_params: Vec<TsTypeDef>,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub decorators: Vec<DecoratorDef>,
 }
 

--- a/src/decorators.rs
+++ b/src/decorators.rs
@@ -18,7 +18,7 @@ use std::fmt::Result as FmtResult;
 #[serde(rename_all = "camelCase")]
 pub struct DecoratorDef {
   pub name: String,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub args: Vec<String>,
   pub location: Location,
 }

--- a/src/enum.rs
+++ b/src/enum.rs
@@ -16,9 +16,9 @@ use crate::Location;
 #[serde(rename_all = "camelCase")]
 pub struct EnumMemberDef {
   pub name: String,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub init: Option<TsTypeDef>,
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub location: Location,
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -19,12 +19,12 @@ use serde::{Deserialize, Serialize};
 pub struct FunctionDef {
   pub params: Vec<ParamDef>,
   pub return_type: Option<TsTypeDef>,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub has_body: bool,
   pub is_async: bool,
   pub is_generator: bool,
   pub type_params: Vec<TsTypeParamDef>,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub decorators: Vec<DecoratorDef>,
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -40,9 +40,9 @@ pub struct InterfaceMethodDef {
   pub name: String,
   pub kind: deno_ast::swc::ast::MethodKind,
   pub location: Location,
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub computed: bool,
   pub optional: bool,
   pub params: Vec<ParamDef>,
@@ -92,10 +92,10 @@ impl Display for InterfaceMethodDef {
 pub struct InterfacePropertyDef {
   pub name: String,
   pub location: Location,
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub params: Vec<ParamDef>,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub readonly: bool,
   pub computed: bool,
   pub optional: bool,
@@ -138,7 +138,7 @@ impl Display for InterfacePropertyDef {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceIndexSignatureDef {
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub readonly: bool,
   pub params: Vec<ParamDef>,
@@ -166,7 +166,7 @@ impl Display for InterfaceIndexSignatureDef {
 #[serde(rename_all = "camelCase")]
 pub struct InterfaceCallSignatureDef {
   pub location: Location,
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
   pub params: Vec<ParamDef>,
   pub ts_type: Option<TsTypeDef>,

--- a/src/js_doc.rs
+++ b/src/js_doc.rs
@@ -20,9 +20,9 @@ lazy_static! {
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct JsDoc {
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub doc: Option<String>,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub tags: Vec<JsDocTag>,
 }
 
@@ -81,12 +81,12 @@ pub enum JsDocTag {
   /// `@callback Predicate comment`
   Callback {
     name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@category comment`
   Category {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@constructor` or `@class`
@@ -94,30 +94,30 @@ pub enum JsDocTag {
   /// `@default {value} comment`
   Default {
     value: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@deprecated comment`
   Deprecated {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@enum {type} comment`
   Enum {
     #[serde(rename = "type")]
     type_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   Example {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@extends {type} comment`
   Extends {
     #[serde(rename = "type")]
     type_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@ignore`
@@ -129,13 +129,13 @@ pub enum JsDocTag {
   /// or `@param {type} [name] comment`
   Param {
     name: String,
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none", default)]
     type_ref: Option<String>,
-    #[serde(skip_serializing_if = "core::ops::Not::not")]
+    #[serde(skip_serializing_if = "core::ops::Not::not", default)]
     optional: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     default: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@public`
@@ -145,9 +145,9 @@ pub enum JsDocTag {
   /// `@property {type} name comment` or `@prop {type} name comment`
   Property {
     name: String,
-    #[serde(rename = "type")]
+    #[serde(rename = "type", default)]
     type_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@protected`
@@ -156,9 +156,9 @@ pub enum JsDocTag {
   ReadOnly,
   /// `@return {type} comment` or `@returns {type} comment`
   Return {
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none", default)]
     type_ref: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@tags allow-read, allow-write`
@@ -168,14 +168,14 @@ pub enum JsDocTag {
   /// `@template T comment`
   Template {
     name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@this {type} comment`
   This {
     #[serde(rename = "type")]
     type_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@typedef {type} name comment`
@@ -183,7 +183,7 @@ pub enum JsDocTag {
     name: String,
     #[serde(rename = "type")]
     type_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   /// `@type {type} comment`
@@ -191,7 +191,7 @@ pub enum JsDocTag {
   TypeRef {
     #[serde(rename = "type")]
     type_ref: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
   Unsupported {

--- a/src/node.rs
+++ b/src/node.rs
@@ -114,31 +114,31 @@ pub struct DocNode {
   pub name: String,
   pub location: Location,
   pub declaration_kind: DeclarationKind,
-  #[serde(skip_serializing_if = "JsDoc::is_empty")]
+  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub function_def: Option<super::function::FunctionDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub variable_def: Option<super::variable::VariableDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub enum_def: Option<super::r#enum::EnumDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub class_def: Option<super::class::ClassDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_alias_def: Option<super::type_alias::TypeAliasDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub namespace_def: Option<NamespaceDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub interface_def: Option<super::interface::InterfaceDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub import_def: Option<ImportDef>,
 }
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -48,7 +48,7 @@ pub enum ParamPatternDef {
 pub struct ParamDef {
   #[serde(flatten)]
   pub pattern: ParamPatternDef,
-  #[serde(skip_serializing_if = "Vec::is_empty")]
+  #[serde(skip_serializing_if = "Vec::is_empty", default)]
   pub decorators: Vec<DecoratorDef>,
   pub ts_type: Option<TsTypeDef>,
 }

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -700,16 +700,16 @@ pub enum LiteralDefKind {
 pub struct LiteralDef {
   pub kind: LiteralDefKind,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub number: Option<f64>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub string: Option<String>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub ts_types: Option<Vec<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub boolean: Option<bool>,
 }
 
@@ -799,9 +799,9 @@ pub struct TsInferDef {
 #[serde(rename_all = "camelCase")]
 pub struct TsImportTypeDef {
   pub specifier: String,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub qualifier: Option<String>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_params: Option<Vec<TsTypeDef>>,
 }
 
@@ -828,14 +828,14 @@ pub struct TsIndexedAccessDef {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TsMappedTypeDef {
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub readonly: Option<TruePlusMinus>,
   pub type_param: Box<TsTypeParamDef>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub name_type: Option<Box<TsTypeDef>>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub optional: Option<TruePlusMinus>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub ts_type: Option<Box<TsTypeDef>>,
 }
 
@@ -845,7 +845,7 @@ pub struct LiteralMethodDef {
   pub name: String,
   pub kind: deno_ast::swc::ast::MethodKind,
   pub params: Vec<ParamDef>,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub computed: bool,
   pub optional: bool,
   pub return_type: Option<TsTypeDef>,
@@ -873,7 +873,7 @@ impl Display for LiteralMethodDef {
 pub struct LiteralPropertyDef {
   pub name: String,
   pub params: Vec<ParamDef>,
-  #[serde(skip_serializing_if = "is_false")]
+  #[serde(skip_serializing_if = "is_false", default)]
   pub readonly: bool,
   pub computed: bool,
   pub optional: bool,
@@ -973,67 +973,67 @@ pub struct TsTypeDef {
 
   pub kind: Option<TsTypeDefKind>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub keyword: Option<String>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub literal: Option<LiteralDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_ref: Option<TsTypeRefDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub union: Option<Vec<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub intersection: Option<Vec<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub array: Option<Box<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub tuple: Option<Vec<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_operator: Option<Box<TsTypeOperatorDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub parenthesized: Option<Box<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub rest: Option<Box<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub optional: Option<Box<TsTypeDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_query: Option<String>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub this: Option<bool>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub fn_or_constructor: Option<Box<TsFnOrConstructorDef>>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub conditional_type: Option<TsConditionalDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub infer: Option<TsInferDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub indexed_access: Option<TsIndexedAccessDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub mapped_type: Option<TsMappedTypeDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_literal: Option<TsTypeLiteralDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub type_predicate: Option<TsTypePredicateDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub import_type: Option<TsImportTypeDef>,
 }
 

--- a/src/ts_type_param.rs
+++ b/src/ts_type_param.rs
@@ -10,10 +10,10 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 pub struct TsTypeParamDef {
   pub name: String,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub constraint: Option<TsTypeDef>,
 
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(skip_serializing_if = "Option::is_none", default)]
   pub default: Option<TsTypeDef>,
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use deno_doc::DocNode;
 use deno_graph::source::Source;
 use pretty_assertions::assert_eq;
 
@@ -77,5 +78,9 @@ async fn test_doc_specs() {
       "Should be same for {}",
       test_file_path.display()
     );
+
+    // Check that the JSON output is round-trippable.
+    let _parsed_json_output: Vec<DocNode> =
+      serde_json::from_str(&json_output).unwrap();
   }
 }


### PR DESCRIPTION
Previously wasn't working, because all the nodes marked as `skip_serializing_if` were not also marked as `default`.
