### PR TITLE
chore: update deno_graph 0.67.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.66.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c67c7c05d70e43560b1dfa38ee385d2d0153ccd4ea16fdc6a706881fd60f3c5"
+checksum = "ea6cd4baa18bce2ee79ba7a047e5168cf3e3de5f53aaae330c13804bb7b4e9fb"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ repository = "https://github.com/denoland/deno_doc"
 members = ["lib"]
 
 [workspace.dependencies]
-deno_graph = { version = "0.66.0", default-features = false, features = ["symbols"] }
+deno_graph = { version = "0.67.0", default-features = false, features = [
+  "symbols",
+] }
 import_map = "0.18.0"
 serde = { version = "1.0.140", features = ["derive"] }
 
@@ -34,13 +36,20 @@ import_map.workspace = true
 lazy_static = "1.4.0"
 regex = "1.6.0"
 serde.workspace = true
-serde_json = { version = "1.0.82", features = [ "preserve_order" ] }
+serde_json = { version = "1.0.82", features = ["preserve_order"] }
 termcolor = "1.1.2"
 
 html-escape = { version = "0.2.13", optional = true }
 comrak = { version = "0.20.0", optional = true, default-features = false }
 handlebars = { version = "5.0", optional = true, features = ["string_helpers"] }
-syntect = { version = "5.1.0", optional = true, default-features = false, features = [ "parsing", "default-syntaxes", "default-themes", "html", "dump-load", "regex-onig" ] }
+syntect = { version = "5.1.0", optional = true, default-features = false, features = [
+  "parsing",
+  "default-syntaxes",
+  "default-themes",
+  "html",
+  "dump-load",
+  "regex-onig",
+] }
 ammonia = { version = "3.3.0", optional = true }
 
 tree-sitter-highlight = { version = "0.20.1", optional = true }
@@ -65,7 +74,17 @@ pretty_assertions = "1.0.0"
 default = ["html", "rust", "ammonia"]
 rust = []
 html = ["html-escape", "comrak", "handlebars"]
-tree-sitter = ["tree-sitter-highlight", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-json", "tree-sitter-regex", "tree-sitter-css", "tree-sitter-toml", "tree-sitter-md", "tree-sitter-rust"]
+tree-sitter = [
+  "tree-sitter-highlight",
+  "tree-sitter-javascript",
+  "tree-sitter-typescript",
+  "tree-sitter-json",
+  "tree-sitter-regex",
+  "tree-sitter-css",
+  "tree-sitter-toml",
+  "tree-sitter-md",
+  "tree-sitter-rust",
+]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Looks like cargo formatted the file a little differently. Only updated `deno_graph`