### PR TITLE
fix(html): dont unwrap get file in exports resolver

### DIFF
--- a/src/html/render_context.rs
+++ b/src/html/render_context.rs
@@ -2,6 +2,7 @@ use crate::html::util::BreadcrumbCtx;
 use crate::html::util::BreadcrumbsCtx;
 use crate::html::util::NamespacedSymbols;
 use crate::html::GenerateCtx;
+use crate::html::ShortPath;
 use crate::html::UrlResolveKind;
 use deno_graph::ModuleSpecifier;
 use std::collections::HashMap;
@@ -101,10 +102,11 @@ impl<'ctx> RenderContext<'ctx> {
         self.ctx.href_resolver.resolve_path(
           self.get_current_resolve(),
           UrlResolveKind::Symbol {
-            file: self
+            file: &self
               .get_current_resolve()
               .get_file()
-              .expect("is in file because has exports"),
+              .cloned()
+              .unwrap_or_else(|| ShortPath::from(String::from("."))),
             symbol: &target_symbol_parts.join("."),
           },
         ),


### PR DESCRIPTION
This actually used to be like this:
<img width="1106" alt="Screenshot 2024-02-22 at 16 14 15" src="https://github.com/denoland/deno_doc/assets/13135287/fc4664dc-b93b-4028-bfe1-2c5dac66792b">

with the difference that I am trying to move away from empty shortpaths.

I wont be adding tests in this PR, but in a follow-up right after (also found a few other issues i'll be addressing there), lets roll this out as quickly as possible