### PR TITLE
feat: `@see` tag

### DIFF
--- a/js/types.d.ts
+++ b/js/types.d.ts
@@ -83,6 +83,7 @@ export interface DocNodeImport extends DocNodeBase {
 export type Accessibility = "public" | "protected" | "private";
 
 export interface ClassDef {
+  defName?: string;
   isAbstract: boolean;
   constructors: ClassConstructorDef[];
   properties: ClassPropertyDef[];
@@ -162,6 +163,7 @@ export interface EnumMemberDef {
 }
 
 export interface FunctionDef {
+  defName?: string;
   params: ParamDef[];
   returnType?: TsTypeDef;
   hasBody?: boolean;
@@ -177,6 +179,7 @@ export interface ImportDef {
 }
 
 export interface InterfaceDef {
+  defName?: string;
   extends: TsTypeDef[];
   methods: InterfaceMethodDef[];
   properties: InterfacePropertyDef[];
@@ -251,11 +254,13 @@ export type JsDocTagKind =
   | "this"
   | "typedef"
   | "type"
+  | "see"
   | "unsupported";
 
 export type JsDocTag =
   | JsDocTagOnly
   | JsDocTagDoc
+  | JsDocTagDocRequired
   | JsDocTagNamed
   | JsDocTagValued
   | JsDocTagTyped
@@ -281,8 +286,13 @@ export interface JsDocTagOnly extends JsDocTagBase {
 }
 
 export interface JsDocTagDoc extends JsDocTagBase {
-  kind: "category" | "deprecated" | "example";
+  kind: "deprecated";
   doc?: string;
+}
+
+export interface JsDocTagDocRequired extends JsDocTagBase {
+  kind: "category" | "example" | "see";
+  doc: string;
 }
 
 export interface JsDocTagNamed extends JsDocTagBase {

--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -259,11 +259,9 @@ pub(crate) fn jsdoc_examples(
     .iter()
     .filter_map(|tag| {
       if let JsDocTag::Example { doc } = tag {
-        doc.as_ref().map(|doc| {
-          let example = ExampleCtx::new(ctx, doc, i);
-          i += 1;
-          example
-        })
+        let example = ExampleCtx::new(ctx, doc, i);
+        i += 1;
+        Some(example)
       } else {
         None
       }

--- a/src/html/symbols/namespace.rs
+++ b/src/html/symbols/namespace.rs
@@ -170,7 +170,7 @@ pub fn partition_nodes_by_category<'a>(
         .iter()
         .find_map(|tag| {
           if let JsDocTag::Category { doc } = tag {
-            doc.as_ref().map(|doc| doc.trim().to_owned())
+            Some(doc.trim().to_owned())
           } else {
             None
           }

--- a/src/js_doc.rs
+++ b/src/js_doc.rs
@@ -613,7 +613,7 @@ if (true) {
       .unwrap(),
       json!({
         "tags": [{
-          "kind":"tags",
+          "kind": "tags",
           "tags": ["allow-read", "allow-write"],
         }]
       })
@@ -622,9 +622,38 @@ if (true) {
       serde_json::to_value(JsDoc::from("@see foo".to_string())).unwrap(),
       json!({
         "tags": [{
-          "kind":"see",
+          "kind": "see",
           "doc": "foo"
         }]
+      })
+    );
+
+    assert_eq!(
+      serde_json::to_value(JsDoc::from(
+        r#"@tags allow-read, allow-write
+@example some example
+const a = "a";
+@category foo
+@see bar
+"#
+        .to_string()
+      ))
+      .unwrap(),
+      json!({
+        "tags": [{
+          "kind": "tags",
+          "tags": ["allow-read", "allow-write"]
+        }, {
+          "kind": "example",
+          "doc": "some example\nconst a = \"a\";"
+        }, {
+          "kind": "category",
+          "doc": "foo"
+        }, {
+          "kind": "see",
+          "doc": "bar"
+        }]
+
       })
     );
   }

--- a/src/js_doc.rs
+++ b/src/js_doc.rs
@@ -5,7 +5,8 @@ use serde::Deserialize;
 use serde::Serialize;
 
 lazy_static! {
-  static ref JS_DOC_TAG_MAYBE_DOC_RE: Regex = Regex::new(r"(?s)^\s*@(category|deprecated|example|tags)(?:\s+(.+))?").unwrap();
+  static ref JS_DOC_TAG_MAYBE_DOC_RE: Regex = Regex::new(r"(?s)^\s*@(deprecated)(?:\s+(.+))?").unwrap();
+  static ref JS_DOC_TAG_DOC_RE: Regex = Regex::new(r"(?s)^\s*@(category|see|example|tags)(?:\s+(.+))").unwrap();
   static ref JS_DOC_TAG_NAMED_RE: Regex = Regex::new(r"(?s)^\s*@(callback|template)\s+([a-zA-Z_$]\S*)(?:\s+(.+))?").unwrap();
   static ref JS_DOC_TAG_NAMED_TYPED_RE: Regex = Regex::new(r"(?s)^\s*@(prop(?:erty)?|typedef)\s+\{([^}]+)\}\s+([a-zA-Z_$]\S*)(?:\s+(.+))?").unwrap();
   static ref JS_DOC_TAG_ONLY_RE: Regex = Regex::new(r"^\s*@(constructor|class|ignore|module|public|private|protected|readonly)").unwrap();
@@ -86,8 +87,8 @@ pub enum JsDocTag {
   },
   /// `@category comment`
   Category {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    doc: Option<String>,
+    #[serde(default)]
+    doc: String,
   },
   /// `@constructor` or `@class`
   Constructor,
@@ -109,9 +110,10 @@ pub enum JsDocTag {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
+  /// `@example comment`
   Example {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    doc: Option<String>,
+    #[serde(default)]
+    doc: String,
   },
   /// `@extends {type} comment`
   Extends {
@@ -194,6 +196,10 @@ pub enum JsDocTag {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     doc: Option<String>,
   },
+  /// `@see comment`
+  See {
+    doc: String,
+  },
   Unsupported {
     value: String,
   },
@@ -259,14 +265,19 @@ impl From<String> for JsDocTag {
       let kind = caps.get(1).unwrap().as_str();
       let doc = caps.get(2).map(|m| m.as_str().to_string());
       match kind {
-        "category" => Self::Category { doc },
         "deprecated" => Self::Deprecated { doc },
+        _ => unreachable!("kind unexpected: {}", kind),
+      }
+    } else if let Some(caps) = JS_DOC_TAG_DOC_RE.captures(&value) {
+      let kind = caps.get(1).unwrap().as_str();
+      let doc = caps.get(2).unwrap().as_str().to_string();
+      match kind {
+        "category" => Self::Category { doc },
         "example" => Self::Example { doc },
         "tags" => Self::Tags {
-          tags: doc
-            .map(|s| s.split(',').map(|i| i.trim().to_string()).collect())
-            .unwrap_or_default(),
+          tags: doc.split(',').map(|i| i.trim().to_string()).collect(),
         },
+        "see" => Self::See { doc },
         _ => unreachable!("kind unexpected: {}", kind),
       }
     } else if let Some(caps) = JS_DOC_TAG_PARAM_RE.captures(&value) {
@@ -548,26 +559,6 @@ if (true) {
   #[test]
   fn test_js_doc_tag_maybe_doc() {
     assert_eq!(
-      serde_json::to_value(JsDoc::from("@category".to_string())).unwrap(),
-      json!({
-        "tags": [{
-          "kind": "category",
-        }]
-      })
-    );
-    assert_eq!(
-      serde_json::to_value(JsDoc::from(
-        "@category Functional Components".to_string()
-      ))
-      .unwrap(),
-      json!({
-        "tags": [{
-          "kind": "category",
-          "doc": "Functional Components",
-        }]
-      })
-    );
-    assert_eq!(
       serde_json::to_value(JsDoc::from("@deprecated".to_string())).unwrap(),
       json!({
         "tags": [{
@@ -587,11 +578,19 @@ if (true) {
         }]
       })
     );
+  }
+
+  #[test]
+  fn test_js_doc_tag_doc() {
     assert_eq!(
-      serde_json::to_value(JsDoc::from("@example".to_string())).unwrap(),
+      serde_json::to_value(JsDoc::from(
+        "@category Functional Components".to_string()
+      ))
+      .unwrap(),
       json!({
         "tags": [{
-          "kind": "example"
+          "kind": "category",
+          "doc": "Functional Components",
         }]
       })
     );
@@ -616,6 +615,15 @@ if (true) {
         "tags": [{
           "kind":"tags",
           "tags": ["allow-read", "allow-write"],
+        }]
+      })
+    );
+    assert_eq!(
+      serde_json::to_value(JsDoc::from("@see foo".to_string())).unwrap(),
+      json!({
+        "tags": [{
+          "kind":"see",
+          "doc": "foo"
         }]
       })
     );

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -204,7 +204,7 @@ impl<'a> DocPrinter<'a> {
   fn format_jsdoc_tag_doc(
     &self,
     w: &mut Formatter<'_>,
-    doc: &String,
+    doc: &str,
     indent: i64,
   ) -> FmtResult {
     for line in doc.lines() {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -201,6 +201,18 @@ impl<'a> DocPrinter<'a> {
     }
   }
 
+  fn format_jsdoc_tag_doc(
+    &self,
+    w: &mut Formatter<'_>,
+    doc: &String,
+    indent: i64,
+  ) -> FmtResult {
+    for line in doc.lines() {
+      writeln!(w, "{}{}", Indent(indent + 2), colors::gray(line))?;
+    }
+    writeln!(w)
+  }
+
   fn format_jsdoc_tag(
     &self,
     w: &mut Formatter<'_>,
@@ -220,7 +232,7 @@ impl<'a> DocPrinter<'a> {
       }
       JsDocTag::Category { doc } => {
         writeln!(w, "{}@{}", Indent(indent), colors::magenta("category"))?;
-        self.format_jsdoc_tag_maybe_doc(w, doc, indent)
+        self.format_jsdoc_tag_doc(w, doc, indent)
       }
       JsDocTag::Constructor => {
         writeln!(w, "{}@{}", Indent(indent), colors::magenta("constructor"))
@@ -251,7 +263,7 @@ impl<'a> DocPrinter<'a> {
       }
       JsDocTag::Example { doc } => {
         writeln!(w, "{}@{}", Indent(indent), colors::magenta("example"))?;
-        self.format_jsdoc_tag_maybe_doc(w, doc, indent)
+        self.format_jsdoc_tag_doc(w, doc, indent)
       }
       JsDocTag::Extends { type_ref, doc } => {
         writeln!(
@@ -388,6 +400,10 @@ impl<'a> DocPrinter<'a> {
           colors::magenta(&name[1..]),
           value
         )
+      }
+      JsDocTag::See { doc } => {
+        writeln!(w, "{}@{}", Indent(indent), colors::magenta("see"))?;
+        self.format_jsdoc_tag_doc(w, doc, indent)
       }
     }
   }


### PR DESCRIPTION
Towards #489. Does not include html gen handling.

This also slightly changes the semantics of `@category`, `@example` & `@tags`, as they allowed for an empty doc content, which makes no sense for these tags.