### PR TITLE
fix(html): don't display destructure import statement in drilldown

### DIFF
--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -10,7 +10,6 @@ use comrak::nodes::NodeHtmlBlock;
 use comrak::nodes::NodeValue;
 use comrak::Arena;
 use deno_ast::ModuleSpecifier;
-use indexmap::IndexMap;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -18,7 +17,6 @@ use std::cmp::Ordering;
 
 #[cfg(feature = "ammonia")]
 use crate::html::comrak_adapters::URLRewriter;
-use crate::html::DocNodeWithContext;
 
 lazy_static! {
   static ref JSDOC_LINK_RE: regex::Regex = regex::Regex::new(
@@ -521,7 +519,7 @@ impl ModuleDocCtx {
   pub fn new(
     render_ctx: &RenderContext,
     specifier: &ModuleSpecifier,
-    doc_nodes_by_url: &IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>,
+    doc_nodes_by_url: &super::ContextDocNodesByUrl,
   ) -> Self {
     let module_doc_nodes = doc_nodes_by_url.get(specifier).unwrap();
 

--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -469,7 +469,7 @@ pub(crate) fn jsdoc_examples(
 
   if !examples.is_empty() {
     Some(SectionCtx {
-      title: "Examples",
+      title: "Examples".to_string(),
       content: SectionContentCtx::Example(examples),
     })
   } else {

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -142,6 +142,7 @@ impl<'ctx> GenerateCtx<'ctx> {
           .map(|node| DocNodeWithContext {
             origin: Rc::new(self.url_to_short_path(&specifier)),
             ns_qualifiers: Rc::new(vec![]),
+            drilldown_parent_kind: None,
             kind_with_drilldown: DocNodeKindWithDrilldown::Other(node.kind),
             inner: Arc::new(node),
           })
@@ -196,6 +197,7 @@ pub enum DocNodeKindWithDrilldown {
 pub struct DocNodeWithContext {
   pub origin: Rc<ShortPath>,
   pub ns_qualifiers: Rc<Vec<String>>,
+  pub drilldown_parent_kind: Option<crate::DocNodeKind>,
   pub kind_with_drilldown: DocNodeKindWithDrilldown,
   pub inner: Arc<DocNode>,
 }
@@ -205,6 +207,7 @@ impl DocNodeWithContext {
     DocNodeWithContext {
       origin: self.origin.clone(),
       ns_qualifiers: self.ns_qualifiers.clone(),
+      drilldown_parent_kind: None,
       kind_with_drilldown: DocNodeKindWithDrilldown::Other(doc_node.kind),
       inner: doc_node,
     }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -133,7 +133,7 @@ impl<'ctx> GenerateCtx<'ctx> {
   pub fn doc_nodes_by_url_add_context(
     &self,
     doc_nodes_by_url: IndexMap<ModuleSpecifier, Vec<DocNode>>,
-  ) -> IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>> {
+  ) -> ContextDocNodesByUrl {
     doc_nodes_by_url
       .into_iter()
       .map(|(specifier, nodes)| {
@@ -153,6 +153,9 @@ impl<'ctx> GenerateCtx<'ctx> {
       .collect::<IndexMap<_, _>>()
   }
 }
+
+pub type ContextDocNodesByUrl =
+  IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>;
 
 #[derive(Clone, Debug)]
 pub struct ShortPath(String);

--- a/src/html/pages.rs
+++ b/src/html/pages.rs
@@ -20,6 +20,7 @@ use super::SEARCH_INDEX_FILENAME;
 use super::STYLESHEET_FILENAME;
 
 use crate::function::FunctionDef;
+use crate::html::partition::Partition;
 use crate::variable::VariableDef;
 use crate::DocNode;
 use crate::DocNodeKind;
@@ -79,8 +80,8 @@ struct IndexCtx {
 pub fn render_index(
   ctx: &GenerateCtx,
   specifier: Option<&ModuleSpecifier>,
-  doc_nodes_by_url: &IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>,
-  partitions: IndexMap<String, Vec<DocNodeWithContext>>,
+  doc_nodes_by_url: &super::ContextDocNodesByUrl,
+  partitions: Partition,
   file: Option<ShortPath>,
 ) -> String {
   let sidepanel_ctx = sidepanels::IndexSidepanelCtx::new(
@@ -146,7 +147,7 @@ struct AllSymbolsCtx {
 
 pub(crate) fn render_all_symbols_page(
   ctx: &GenerateCtx,
-  partitions: IndexMap<String, Vec<DocNodeWithContext>>,
+  partitions: Partition,
 ) -> String {
   // TODO(@crowlKats): handle doc_nodes in all symbols page for each symbol
   let render_ctx =
@@ -189,7 +190,7 @@ pub fn generate_symbol_pages_for_module(
   ctx: &GenerateCtx,
   current_specifier: &ModuleSpecifier,
   short_path: &ShortPath,
-  partitions_for_nodes: &IndexMap<String, Vec<DocNodeWithContext>>,
+  partitions_for_nodes: &Partition,
   doc_nodes: &[DocNodeWithContext],
 ) -> Vec<SymbolPage> {
   let mut name_partitions =
@@ -316,8 +317,8 @@ pub fn generate_symbol_pages_for_module(
 fn generate_symbol_pages_inner(
   ctx: &GenerateCtx,
   doc_nodes_for_module: &[DocNodeWithContext],
-  partitions_for_nodes: &IndexMap<String, Vec<DocNodeWithContext>>,
-  name_partitions: &IndexMap<String, Vec<DocNodeWithContext>>,
+  partitions_for_nodes: &Partition,
+  name_partitions: &Partition,
   current_specifier: &ModuleSpecifier,
   short_path: &ShortPath,
   namespace_paths: Vec<&str>,

--- a/src/html/pages.rs
+++ b/src/html/pages.rs
@@ -146,7 +146,7 @@ struct AllSymbolsCtx {
 
 pub(crate) fn render_all_symbols_page(
   ctx: &GenerateCtx,
-  partitions: IndexMap<DocNodeKindWithDrilldown, Vec<DocNodeWithContext>>,
+  partitions: IndexMap<String, Vec<DocNodeWithContext>>,
 ) -> String {
   // TODO(@crowlKats): handle doc_nodes in all symbols page for each symbol
   let render_ctx =
@@ -211,6 +211,7 @@ pub fn generate_symbol_pages_for_module(
               method.js_doc.clone(),
               method.function_def.clone(),
             )));
+          new_node.drilldown_parent_kind = Some(DocNodeKind::Class);
           new_node.kind_with_drilldown = DocNodeKindWithDrilldown::Method;
           new_node
         })
@@ -234,6 +235,7 @@ pub fn generate_symbol_pages_for_module(
                 kind: deno_ast::swc::ast::VarDeclKind::Const,
               },
             )));
+          new_node.drilldown_parent_kind = Some(DocNodeKind::Class);
           new_node.kind_with_drilldown = DocNodeKindWithDrilldown::Property;
           new_node
         })
@@ -264,6 +266,7 @@ pub fn generate_symbol_pages_for_module(
                 decorators: vec![],
               },
             )));
+          new_node.drilldown_parent_kind = Some(DocNodeKind::Interface);
           new_node.kind_with_drilldown = DocNodeKindWithDrilldown::Method;
           new_node
         })
@@ -287,6 +290,7 @@ pub fn generate_symbol_pages_for_module(
                 kind: deno_ast::swc::ast::VarDeclKind::Const,
               },
             )));
+          new_node.drilldown_parent_kind = Some(DocNodeKind::Interface);
           new_node.kind_with_drilldown = DocNodeKindWithDrilldown::Property;
           new_node
         })

--- a/src/html/partition.rs
+++ b/src/html/partition.rs
@@ -3,14 +3,13 @@ use super::DocNodeWithContext;
 use super::GenerateCtx;
 use crate::js_doc::JsDocTag;
 use crate::DocNodeKind;
-use deno_ast::ModuleSpecifier;
 use indexmap::IndexMap;
 use std::cmp::Ordering;
 use std::rc::Rc;
 
-pub fn partition_nodes_by_name(
-  doc_nodes: &[DocNodeWithContext],
-) -> IndexMap<String, Vec<DocNodeWithContext>> {
+pub type Partition = IndexMap<String, Vec<DocNodeWithContext>>;
+
+pub fn partition_nodes_by_name(doc_nodes: &[DocNodeWithContext]) -> Partition {
   let mut partitions = IndexMap::default();
 
   for node in doc_nodes {
@@ -38,7 +37,7 @@ pub fn partition_nodes_by_name(
 pub fn partition_nodes_by_kind(
   doc_nodes: &[DocNodeWithContext],
   flatten_namespaces: bool,
-) -> IndexMap<String, Vec<DocNodeWithContext>> {
+) -> Partition {
   fn partition_nodes_by_kind_inner(
     partitions: &mut IndexMap<
       DocNodeKindWithDrilldown,
@@ -97,10 +96,7 @@ pub fn partition_nodes_by_kind(
     }
   }
 
-  let mut partitions: IndexMap<
-    DocNodeKindWithDrilldown,
-    Vec<DocNodeWithContext>,
-  > = IndexMap::default();
+  let mut partitions = IndexMap::default();
 
   partition_nodes_by_kind_inner(&mut partitions, doc_nodes, flatten_namespaces);
 
@@ -142,9 +138,9 @@ pub fn partition_nodes_by_kind(
 pub fn partition_nodes_by_category(
   doc_nodes: &[DocNodeWithContext],
   flatten_namespaces: bool,
-) -> IndexMap<String, Vec<DocNodeWithContext>> {
+) -> Partition {
   fn partition_nodes_by_category_inner(
-    partitions: &mut IndexMap<String, Vec<DocNodeWithContext>>,
+    partitions: &mut Partition,
     doc_nodes: &[DocNodeWithContext],
     flatten_namespaces: bool,
   ) {
@@ -201,8 +197,7 @@ pub fn partition_nodes_by_category(
     }
   }
 
-  let mut partitions: IndexMap<String, Vec<DocNodeWithContext>> =
-    IndexMap::default();
+  let mut partitions = IndexMap::default();
 
   partition_nodes_by_category_inner(
     &mut partitions,
@@ -232,7 +227,7 @@ pub fn partition_nodes_by_category(
 pub fn get_partitions_for_file(
   ctx: &GenerateCtx,
   doc_nodes: &[DocNodeWithContext],
-) -> IndexMap<String, Vec<DocNodeWithContext>> {
+) -> Partition {
   let categories =
     partition_nodes_by_category(doc_nodes, ctx.sidebar_flatten_namespaces);
 
@@ -245,8 +240,8 @@ pub fn get_partitions_for_file(
 
 pub fn get_partitions_for_main_entrypoint(
   ctx: &GenerateCtx,
-  doc_nodes_by_url: &IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>,
-) -> IndexMap<String, Vec<DocNodeWithContext>> {
+  doc_nodes_by_url: &super::ContextDocNodesByUrl,
+) -> Partition {
   let doc_nodes = ctx
     .main_entrypoint
     .as_ref()

--- a/src/html/render_context.rs
+++ b/src/html/render_context.rs
@@ -352,6 +352,7 @@ mod test {
         ),
       ),
       ns_qualifiers: Rc::new(vec![]),
+      drilldown_parent_kind: None,
       kind_with_drilldown: DocNodeKindWithDrilldown::Other(DocNodeKind::Import),
       inner: Arc::new(DocNode {
         kind: DocNodeKind::Import,

--- a/src/html/search.rs
+++ b/src/html/search.rs
@@ -1,5 +1,6 @@
-use crate::html::DocNodeWithContext;
-use crate::html::GenerateCtx;
+use super::ContextDocNodesByUrl;
+use super::DocNodeWithContext;
+use super::GenerateCtx;
 use crate::node::Location;
 use crate::DocNodeKind;
 use deno_ast::ModuleSpecifier;
@@ -170,7 +171,7 @@ fn doc_node_into_search_index_nodes(
 
 pub fn generate_search_index(
   ctx: &GenerateCtx,
-  doc_nodes_by_url: &IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>,
+  doc_nodes_by_url: &ContextDocNodesByUrl,
 ) -> serde_json::Value {
   let doc_nodes = doc_nodes_by_url.values().flatten().collect::<Vec<_>>();
 
@@ -211,7 +212,7 @@ pub fn generate_search_index(
 
 pub(crate) fn get_search_index_file(
   ctx: &GenerateCtx,
-  doc_nodes_by_url: &IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>,
+  doc_nodes_by_url: &ContextDocNodesByUrl,
 ) -> Result<String, anyhow::Error> {
   let search_index = generate_search_index(ctx, doc_nodes_by_url);
   let search_index_str = serde_json::to_string(&search_index)?;

--- a/src/html/search.rs
+++ b/src/html/search.rs
@@ -157,6 +157,7 @@ fn doc_node_into_search_index_nodes(
         &[&DocNodeWithContext {
           origin: doc_nodes[0].origin.clone(),
           ns_qualifiers: Rc::new(ns_qualifiers_),
+          drilldown_parent_kind: None,
           kind_with_drilldown: el_nodes[0].kind_with_drilldown,
           inner: el_nodes[0].inner.clone(),
         }],

--- a/src/html/sidepanels.rs
+++ b/src/html/sidepanels.rs
@@ -1,3 +1,4 @@
+use super::partition::Partition;
 use super::DocNodeKindCtx;
 use super::DocNodeWithContext;
 use super::GenerateCtx;
@@ -51,7 +52,7 @@ pub struct SidepanelCtx {
 impl SidepanelCtx {
   pub fn new(
     ctx: &GenerateCtx,
-    partitions: &IndexMap<String, Vec<DocNodeWithContext>>,
+    partitions: &Partition,
     file: &ShortPath,
     symbol: &str,
   ) -> Self {
@@ -116,8 +117,8 @@ impl IndexSidepanelCtx {
   pub fn new(
     ctx: &GenerateCtx,
     current_entrypoint: Option<&ModuleSpecifier>,
-    doc_nodes_by_url: &IndexMap<ModuleSpecifier, Vec<DocNodeWithContext>>,
-    partitions: IndexMap<String, Vec<DocNodeWithContext>>,
+    doc_nodes_by_url: &super::ContextDocNodesByUrl,
+    partitions: Partition,
     current_file: Option<&ShortPath>,
   ) -> Self {
     let files = doc_nodes_by_url

--- a/src/html/symbols/class.rs
+++ b/src/html/symbols/class.rs
@@ -57,7 +57,7 @@ pub(crate) fn render_class(
 
   if !class_items.properties.is_empty() {
     sections.push(SectionCtx {
-      title: "Properties",
+      title: "Properties".to_string(),
       content: SectionContentCtx::DocEntry(render_class_properties(
         ctx,
         doc_node.get_name(),
@@ -68,7 +68,7 @@ pub(crate) fn render_class(
 
   if !class_items.methods.is_empty() {
     sections.push(SectionCtx {
-      title: "Methods",
+      title: "Methods".to_string(),
       content: SectionContentCtx::DocEntry(render_class_methods(
         ctx,
         doc_node.get_name(),
@@ -79,7 +79,7 @@ pub(crate) fn render_class(
 
   if !class_items.static_properties.is_empty() {
     sections.push(SectionCtx {
-      title: "Static Properties",
+      title: "Static Properties".to_string(),
       content: SectionContentCtx::DocEntry(render_class_properties(
         ctx,
         doc_node.get_name(),
@@ -90,7 +90,7 @@ pub(crate) fn render_class(
 
   if !class_items.static_methods.is_empty() {
     sections.push(SectionCtx {
-      title: "Static Methods",
+      title: "Static Methods".to_string(),
       content: SectionContentCtx::DocEntry(render_class_methods(
         ctx,
         doc_node.get_name(),
@@ -139,7 +139,7 @@ fn render_constructors(
     .collect::<Vec<DocEntryCtx>>();
 
   Some(SectionCtx {
-    title: "Constructors",
+    title: "Constructors".to_string(),
     content: SectionContentCtx::DocEntry(items),
   })
 }
@@ -187,7 +187,7 @@ fn render_index_signatures(
   }
 
   Some(SectionCtx {
-    title: "Index Signatures",
+    title: "Index Signatures".to_string(),
     content: SectionContentCtx::IndexSignature(items),
   })
 }

--- a/src/html/symbols/enum.rs
+++ b/src/html/symbols/enum.rs
@@ -39,7 +39,7 @@ pub(crate) fn render_enum(
     .collect::<Vec<DocEntryCtx>>();
 
   vec![SectionCtx {
-    title: "Members",
+    title: "Members".to_string(),
     content: SectionContentCtx::DocEntry(items),
   }]
 }

--- a/src/html/symbols/function.rs
+++ b/src/html/symbols/function.rs
@@ -259,13 +259,13 @@ fn render_single_function(
 
   if !params.is_empty() {
     sections.push(SectionCtx {
-      title: "Parameters",
+      title: "Parameters".to_string(),
       content: SectionContentCtx::DocEntry(params),
     });
   }
 
   sections.push(SectionCtx {
-    title: "Return Type",
+    title: "Return Type".to_string(),
     content: SectionContentCtx::DocEntry(
       render_function_return_type(ctx, function_def, doc_node, overload_id)
         .map_or_else(Default::default, |doc_entry| vec![doc_entry]),

--- a/src/html/symbols/interface.rs
+++ b/src/html/symbols/interface.rs
@@ -90,7 +90,7 @@ fn render_index_signatures(
   }
 
   Some(SectionCtx {
-    title: "Index Signatures",
+    title: "Index Signatures".to_string(),
     content: SectionContentCtx::IndexSignature(items),
   })
 }
@@ -135,7 +135,7 @@ fn render_call_signatures(
     .collect::<Vec<DocEntryCtx>>();
 
   Some(SectionCtx {
-    title: "Call Signatures",
+    title: "Call Signatures".to_string(),
     content: SectionContentCtx::DocEntry(items),
   })
 }
@@ -205,7 +205,7 @@ fn render_properties(
     .collect::<Vec<DocEntryCtx>>();
 
   Some(SectionCtx {
-    title: "Properties",
+    title: "Properties".to_string(),
     content: SectionContentCtx::DocEntry(items),
   })
 }
@@ -266,7 +266,7 @@ fn render_methods(
     .collect::<Vec<DocEntryCtx>>();
 
   Some(SectionCtx {
-    title: "Methods",
+    title: "Methods".to_string(),
     content: SectionContentCtx::DocEntry(items),
   })
 }

--- a/src/html/symbols/namespace.rs
+++ b/src/html/symbols/namespace.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 pub fn render_namespace(
   ctx: &RenderContext,
-  partitions: IndexMap<String, Vec<DocNodeWithContext>>,
+  partitions: super::super::partition::Partition,
 ) -> Vec<SectionCtx> {
   partitions
     .into_iter()

--- a/src/html/symbols/namespace.rs
+++ b/src/html/symbols/namespace.rs
@@ -1,6 +1,5 @@
 use crate::html::render_context::RenderContext;
 use crate::html::util::*;
-use crate::html::DocNodeKindWithDrilldown;
 use crate::html::DocNodeWithContext;
 use indexmap::IndexMap;
 use serde::Serialize;
@@ -8,23 +7,21 @@ use std::collections::HashSet;
 
 pub fn render_namespace(
   ctx: &RenderContext,
-  partitions: IndexMap<DocNodeKindWithDrilldown, Vec<DocNodeWithContext>>,
+  partitions: IndexMap<String, Vec<DocNodeWithContext>>,
 ) -> Vec<SectionCtx> {
   partitions
     .into_iter()
-    .map(|(kind, doc_nodes)| {
-      get_namespace_section_render_ctx(ctx, kind, doc_nodes)
+    .map(|(title, doc_nodes)| {
+      get_namespace_section_render_ctx(ctx, title, doc_nodes)
     })
     .collect()
 }
 
 fn get_namespace_section_render_ctx(
   ctx: &RenderContext,
-  kind: DocNodeKindWithDrilldown,
+  title: String,
   doc_nodes: Vec<DocNodeWithContext>,
 ) -> SectionCtx {
-  let kind_ctx = super::super::util::DocNodeKindCtx::from(kind);
-
   let mut grouped_nodes = IndexMap::new();
 
   for node in doc_nodes {
@@ -44,7 +41,7 @@ fn get_namespace_section_render_ctx(
     .collect::<Vec<_>>();
 
   SectionCtx {
-    title: kind_ctx.title_plural,
+    title,
     content: SectionContentCtx::NamespaceSection(nodes),
   }
 }

--- a/src/html/symbols/type_alias.rs
+++ b/src/html/symbols/type_alias.rs
@@ -33,7 +33,7 @@ pub(crate) fn render_type_alias(
   }
 
   sections.push(SectionCtx {
-    title: "Definition",
+    title: "Definition".to_string(),
     content: SectionContentCtx::DocEntry(vec![DocEntryCtx::new(
       ctx,
       &id,

--- a/src/html/symbols/variable.rs
+++ b/src/html/symbols/variable.rs
@@ -17,7 +17,7 @@ pub(crate) fn render_variable(
   let id = name_to_id("variable", doc_node.get_name());
 
   vec![SectionCtx {
-    title: "Type",
+    title: "Type".to_string(),
     content: SectionContentCtx::DocEntry(vec![DocEntryCtx::new(
       ctx,
       &id,

--- a/src/html/types.rs
+++ b/src/html/types.rs
@@ -572,7 +572,7 @@ pub(crate) fn render_type_params(
   }
 
   Some(SectionCtx {
-    title: "Type Parameters",
+    title: "Type Parameters".to_string(),
     content: SectionContentCtx::DocEntry(items),
   })
 }

--- a/src/html/usage.rs
+++ b/src/html/usage.rs
@@ -40,7 +40,12 @@ pub fn usage_to_md(
       parts[0].to_string()
     };
 
-    let usage_symbol = if parts.len() > 1 {
+    let usage_symbol = if doc_nodes
+      .iter()
+      .all(|node| node.drilldown_parent_kind.is_some())
+    {
+      None
+    } else if parts.len() > 1 {
       parts.pop().map(|usage_symbol| {
         (
           usage_symbol,
@@ -55,7 +60,7 @@ pub fn usage_to_md(
 
     let is_type = doc_nodes.iter().all(|doc_node| {
       matches!(
-        doc_node.kind,
+        doc_node.drilldown_parent_kind.unwrap_or(doc_node.kind),
         DocNodeKind::TypeAlias | DocNodeKind::Interface
       )
     });

--- a/src/html/util.rs
+++ b/src/html/util.rs
@@ -313,7 +313,7 @@ pub enum SectionContentCtx {
 
 #[derive(Debug, Serialize, Clone)]
 pub struct SectionCtx {
-  pub title: &'static str,
+  pub title: String,
   pub content: SectionContentCtx,
 }
 

--- a/tests/testdata/symbol_group-syntect.json
+++ b/tests/testdata/symbol_group-syntect.json
@@ -14,7 +14,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -64,7 +64,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -168,7 +168,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -218,7 +218,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -371,7 +371,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -421,7 +421,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -521,7 +521,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -571,7 +571,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -685,7 +685,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -735,7 +735,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -809,7 +809,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Foo } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span><span style=\"font-weight:bold;color:#a71d5d;\">const </span><span style=\"color:#323232;\">{ </span><span style=\"color:#0086b3;\">bar </span><span style=\"color:#323232;\">} </span><span style=\"font-weight:bold;color:#a71d5d;\">= </span><span style=\"color:#323232;\">Foo;\n</span></code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { bar } = Foo;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Foo } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span></code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -856,7 +856,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -906,7 +906,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -980,7 +980,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Foo } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span><span style=\"font-weight:bold;color:#a71d5d;\">const </span><span style=\"color:#323232;\">{ &amp;</span><span style=\"color:#0086b3;\">quot</span><span style=\"color:#323232;\">;&amp;</span><span style=\"color:#0086b3;\">gt</span><span style=\"color:#323232;\">;&amp;</span><span style=\"color:#0086b3;\">lt</span><span style=\"color:#323232;\">;</span><span style=\"color:#0086b3;\">img src</span><span style=\"font-weight:bold;color:#a71d5d;\">=</span><span style=\"color:#323232;\">x onerror</span><span style=\"font-weight:bold;color:#a71d5d;\">=</span><span style=\"font-weight:bold;color:#795da3;\">alert</span><span style=\"color:#323232;\">(</span><span style=\"color:#0086b3;\">1</span><span style=\"color:#323232;\">)</span><span style=\"font-weight:bold;color:#a71d5d;\">&amp;</span><span style=\"color:#323232;\">gt; } </span><span style=\"font-weight:bold;color:#a71d5d;\">= </span><span style=\"color:#0086b3;\">Foo</span><span style=\"color:#323232;\">.prototype;\n</span></code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { &amp;quot;&amp;gt;&amp;lt;img src=x onerror=alert(1)&amp;gt; } = Foo.prototype;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Foo } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span></code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1034,7 +1034,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -1084,7 +1084,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -1158,7 +1158,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Foo } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span><span style=\"font-weight:bold;color:#a71d5d;\">const </span><span style=\"color:#323232;\">{ </span><span style=\"color:#0086b3;\">foo </span><span style=\"color:#323232;\">} </span><span style=\"font-weight:bold;color:#a71d5d;\">= </span><span style=\"color:#0086b3;\">Foo</span><span style=\"color:#323232;\">.prototype;\n</span></code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { foo } = Foo.prototype;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Foo } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span></code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1212,7 +1212,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -1262,7 +1262,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -1336,7 +1336,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ Hello } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span><span style=\"font-weight:bold;color:#a71d5d;\">const </span><span style=\"color:#323232;\">{ </span><span style=\"color:#0086b3;\">world </span><span style=\"color:#323232;\">} </span><span style=\"font-weight:bold;color:#a71d5d;\">= </span><span style=\"color:#323232;\">Hello;\n</span></code><button class=\"context_button\" data-copy=\"import { Hello } from &quot;.&quot;;\nconst { world } = Hello;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ </span><span style=\"font-weight:bold;color:#a71d5d;\">type </span><span style=\"color:#323232;\">Hello } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span></code><button class=\"context_button\" data-copy=\"import { type Hello } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1383,7 +1383,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Function",
+          "name": "Functions",
           "symbols": [
             {
               "kind": [

--- a/tests/testdata/symbol_group-tree-sitter.json
+++ b/tests/testdata/symbol_group-tree-sitter.json
@@ -14,7 +14,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -64,7 +64,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -168,7 +168,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -218,7 +218,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -371,7 +371,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -421,7 +421,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -521,7 +521,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -571,7 +571,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -685,7 +685,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -735,7 +735,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -809,7 +809,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Foo } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n<span class=\"pl-k\">const</span> { bar } <span class=\"pl-c1\">=</span> Foo;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { bar } = Foo;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Foo } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -856,7 +856,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -906,7 +906,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -980,7 +980,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Foo } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n<span class=\"pl-k\">const</span> { <span class=\"pl-c1\">&amp;</span>quot;<span class=\"pl-c1\">&amp;</span>gt;<span class=\"pl-c1\">&amp;</span>lt;img src<span class=\"pl-c1\">=</span>x onerror<span class=\"pl-c1\">=</span>alert(<span class=\"pl-c1\">1</span>)<span class=\"pl-c1\">&amp;</span>gt; } <span class=\"pl-c1\">=</span> Foo.<span class=\"pl-c1\">prototype</span>;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { &amp;quot;&amp;gt;&amp;lt;img src=x onerror=alert(1)&amp;gt; } = Foo.prototype;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Foo } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1034,7 +1034,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -1084,7 +1084,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -1158,7 +1158,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Foo } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n<span class=\"pl-k\">const</span> { foo } <span class=\"pl-c1\">=</span> Foo.<span class=\"pl-c1\">prototype</span>;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { foo } = Foo.prototype;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Foo } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1212,7 +1212,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -1262,7 +1262,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -1336,7 +1336,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { Hello } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n<span class=\"pl-k\">const</span> { world } <span class=\"pl-c1\">=</span> Hello;\n</code><button class=\"context_button\" data-copy=\"import { Hello } from &quot;.&quot;;\nconst { world } = Hello;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { <span class=\"pl-k\">type</span> Hello } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n</code><button class=\"context_button\" data-copy=\"import { type Hello } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1383,7 +1383,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Function",
+          "name": "Functions",
           "symbols": [
             {
               "kind": [

--- a/tests/testdata/symbol_group.json
+++ b/tests/testdata/symbol_group.json
@@ -14,7 +14,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -64,7 +64,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -168,7 +168,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -218,7 +218,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -371,7 +371,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -421,7 +421,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -521,7 +521,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -571,7 +571,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -685,7 +685,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -735,7 +735,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -809,7 +809,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Foo } from \".\";\nconst { bar } = Foo;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { bar } = Foo;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Foo } from \".\";\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -856,7 +856,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -906,7 +906,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -980,7 +980,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Foo } from \".\";\nconst { \"&gt;&lt;img src=x onerror=alert(1)&gt; } = Foo.prototype;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { &amp;quot;&amp;gt;&amp;lt;img src=x onerror=alert(1)&amp;gt; } = Foo.prototype;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Foo } from \".\";\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1034,7 +1034,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -1084,7 +1084,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -1158,7 +1158,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Foo } from \".\";\nconst { foo } = Foo.prototype;\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\nconst { foo } = Foo.prototype;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Foo } from \".\";\n</code><button class=\"context_button\" data-copy=\"import { Foo } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1212,7 +1212,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Class",
+          "name": "Classes",
           "symbols": [
             {
               "kind": [
@@ -1262,7 +1262,7 @@
           ]
         },
         {
-          "name": "Interface",
+          "name": "Interfaces",
           "symbols": [
             {
               "kind": [
@@ -1336,7 +1336,7 @@
         "usages": [
           {
             "name": "",
-            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { Hello } from \".\";\nconst { world } = Hello;\n</code><button class=\"context_button\" data-copy=\"import { Hello } from &quot;.&quot;;\nconst { world } = Hello;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { type Hello } from \".\";\n</code><button class=\"context_button\" data-copy=\"import { type Hello } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
             "additional_css": ""
           }
         ]
@@ -1383,7 +1383,7 @@
       "package_name": null,
       "partitions": [
         {
-          "name": "Function",
+          "name": "Functions",
           "symbols": [
             {
               "kind": [


### PR DESCRIPTION
main change is in src/html/usage.rs
also unifies type of partitioning functions