### PR TITLE
feat: support Location for ts literals, render ts literals as interfaces

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -18,6 +18,7 @@ use crate::params::prop_name_to_string;
 use crate::params::ts_fn_param_to_param_def;
 use crate::ts_type::infer_ts_type_from_expr;
 use crate::ts_type::maybe_type_param_instantiation_to_type_defs;
+use crate::ts_type::IndexSignatureDef;
 use crate::ts_type::TsTypeDef;
 use crate::ts_type_param::maybe_type_param_decl_to_type_param_defs;
 use crate::ts_type_param::TsTypeParamDef;
@@ -161,33 +162,6 @@ impl Display for ClassPropertyDef {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct ClassIndexSignatureDef {
-  #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
-  pub js_doc: JsDoc,
-  pub readonly: bool,
-  pub params: Vec<ParamDef>,
-  pub ts_type: Option<TsTypeDef>,
-  pub location: Location,
-}
-
-#[cfg(feature = "rust")]
-impl Display for ClassIndexSignatureDef {
-  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-    write!(
-      f,
-      "{}[{}]",
-      display_readonly(self.readonly),
-      SliceDisplayer::new(&self.params, ", ", false)
-    )?;
-    if let Some(ts_type) = &self.ts_type {
-      write!(f, ": {}", ts_type)?;
-    }
-    Ok(())
-  }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct ClassMethodDef {
   #[serde(skip_serializing_if = "JsDoc::is_empty", default)]
   pub js_doc: JsDoc,
@@ -248,7 +222,7 @@ pub struct ClassDef {
   pub is_abstract: bool,
   pub constructors: Vec<ClassConstructorDef>,
   pub properties: Vec<ClassPropertyDef>,
-  pub index_signatures: Vec<ClassIndexSignatureDef>,
+  pub index_signatures: Vec<IndexSignatureDef>,
   pub methods: Vec<ClassMethodDef>,
   pub extends: Option<String>,
   pub implements: Vec<TsTypeDef>,
@@ -434,7 +408,7 @@ pub fn class_to_class_def(
             .as_ref()
             .map(|rt| TsTypeDef::new(parsed_source, &rt.type_ann));
 
-          let index_sig_def = ClassIndexSignatureDef {
+          let index_sig_def = IndexSignatureDef {
             location: get_location(parsed_source, ts_index_sig.start()),
             js_doc,
             readonly: ts_index_sig.readonly,

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -289,6 +289,38 @@ impl DocNodeWithContext {
       inner: doc_node,
     }
   }
+
+  pub fn create_child_method(
+    &self,
+    mut method_doc_node: DocNode,
+    parent_name: &str,
+    is_static: bool,
+  ) -> Self {
+    method_doc_node.name =
+      qualify_drilldown_name(parent_name, &method_doc_node.name, is_static);
+    method_doc_node.declaration_kind = self.declaration_kind;
+
+    let mut new_node = self.create_child(Arc::new(method_doc_node));
+    new_node.drilldown_parent_kind = Some(self.kind);
+    new_node.kind_with_drilldown = DocNodeKindWithDrilldown::Method;
+    new_node
+  }
+
+  pub fn create_child_property(
+    &self,
+    mut property_doc_node: DocNode,
+    parent_name: &str,
+    is_static: bool,
+  ) -> Self {
+    property_doc_node.name =
+      qualify_drilldown_name(parent_name, &property_doc_node.name, is_static);
+    property_doc_node.declaration_kind = self.declaration_kind;
+
+    let mut new_node = self.create_child(Arc::new(property_doc_node));
+    new_node.drilldown_parent_kind = Some(self.kind);
+    new_node.kind_with_drilldown = DocNodeKindWithDrilldown::Property;
+    new_node
+  }
 }
 
 impl core::ops::Deref for DocNodeWithContext {

--- a/src/html/symbols/class.rs
+++ b/src/html/symbols/class.rs
@@ -50,7 +50,7 @@ pub(crate) fn render_class(
   }
 
   if let Some(index_signatures) =
-    render_index_signatures(ctx, &class_def.index_signatures)
+    super::interface::render_index_signatures(ctx, &class_def.index_signatures)
   {
     sections.push(index_signatures);
   }
@@ -152,44 +152,6 @@ pub struct IndexSignatureCtx {
   pub params: String,
   pub ts_type: String,
   pub source_href: Option<String>,
-}
-
-fn render_index_signatures(
-  ctx: &RenderContext,
-  index_signatures: &[crate::class::ClassIndexSignatureDef],
-) -> Option<SectionCtx> {
-  if index_signatures.is_empty() {
-    return None;
-  }
-
-  let mut items = Vec::with_capacity(index_signatures.len());
-
-  for (i, index_signature) in index_signatures.iter().enumerate() {
-    let id = name_to_id("index_signature", &i.to_string());
-
-    let ts_type = index_signature
-      .ts_type
-      .as_ref()
-      .map(|ts_type| render_type_def_colon(ctx, ts_type))
-      .unwrap_or_default();
-
-    items.push(IndexSignatureCtx {
-      id: id.clone(),
-      anchor: AnchorCtx { id },
-      readonly: index_signature.readonly,
-      params: render_params(ctx, &index_signature.params),
-      ts_type,
-      source_href: ctx
-        .ctx
-        .href_resolver
-        .resolve_source(&index_signature.location),
-    });
-  }
-
-  Some(SectionCtx::new(
-    "Index Signatures",
-    SectionContentCtx::IndexSignature(items),
-  ))
 }
 
 enum PropertyOrMethod {

--- a/src/html/symbols/interface.rs
+++ b/src/html/symbols/interface.rs
@@ -57,9 +57,9 @@ pub(crate) fn render_interface(
   sections
 }
 
-fn render_index_signatures(
+pub fn render_index_signatures(
   ctx: &RenderContext,
-  index_signatures: &[crate::interface::InterfaceIndexSignatureDef],
+  index_signatures: &[crate::ts_type::IndexSignatureDef],
 ) -> Option<SectionCtx> {
   if index_signatures.is_empty() {
     return None;
@@ -95,9 +95,9 @@ fn render_index_signatures(
   ))
 }
 
-fn render_call_signatures(
+pub fn render_call_signatures(
   ctx: &RenderContext,
-  call_signatures: &[crate::interface::InterfaceCallSignatureDef],
+  call_signatures: &[crate::ts_type::CallSignatureDef],
 ) -> Option<SectionCtx> {
   if call_signatures.is_empty() {
     return None;
@@ -140,10 +140,10 @@ fn render_call_signatures(
   ))
 }
 
-fn render_properties(
+pub fn render_properties(
   ctx: &RenderContext,
   interface_name: &str,
-  properties: &[crate::interface::InterfacePropertyDef],
+  properties: &[crate::ts_type::PropertyDef],
 ) -> Option<SectionCtx> {
   if properties.is_empty() {
     return None;
@@ -210,10 +210,10 @@ fn render_properties(
   ))
 }
 
-fn render_methods(
+pub fn render_methods(
   ctx: &RenderContext,
   interface_name: &str,
-  methods: &[crate::interface::InterfaceMethodDef],
+  methods: &[crate::ts_type::MethodDef],
 ) -> Option<SectionCtx> {
   if methods.is_empty() {
     return None;

--- a/src/html/symbols/type_alias.rs
+++ b/src/html/symbols/type_alias.rs
@@ -1,4 +1,8 @@
 use crate::html::render_context::RenderContext;
+use crate::html::symbols::interface::render_call_signatures;
+use crate::html::symbols::interface::render_index_signatures;
+use crate::html::symbols::interface::render_methods;
+use crate::html::symbols::interface::render_properties;
 use crate::html::types::render_type_def;
 use crate::html::util::*;
 use crate::html::DocNodeWithContext;
@@ -32,19 +36,45 @@ pub(crate) fn render_type_alias(
     sections.push(type_params);
   }
 
-  sections.push(SectionCtx::new(
-    "Definition",
-    SectionContentCtx::DocEntry(vec![DocEntryCtx::new(
-      ctx,
-      &id,
-      "",
-      None,
-      &render_type_def(ctx, &type_alias_def.ts_type),
-      HashSet::new(),
-      None,
-      &doc_node.location,
-    )]),
-  ));
+  if let Some(ts_type_literal) = type_alias_def.ts_type.type_literal.as_ref() {
+    if let Some(index_signatures) =
+      render_index_signatures(ctx, &ts_type_literal.index_signatures)
+    {
+      sections.push(index_signatures);
+    }
+
+    if let Some(call_signatures) =
+      render_call_signatures(ctx, &ts_type_literal.call_signatures)
+    {
+      sections.push(call_signatures);
+    }
+
+    if let Some(properties) =
+      render_properties(ctx, doc_node.get_name(), &ts_type_literal.properties)
+    {
+      sections.push(properties);
+    }
+
+    if let Some(methods) =
+      render_methods(ctx, doc_node.get_name(), &ts_type_literal.methods)
+    {
+      sections.push(methods);
+    }
+  } else {
+    sections.push(SectionCtx::new(
+      "Definition",
+      SectionContentCtx::DocEntry(vec![DocEntryCtx::new(
+        ctx,
+        &id,
+        "",
+        None,
+        &render_type_def(ctx, &type_alias_def.ts_type),
+        HashSet::new(),
+        None,
+        &doc_node.location,
+      )]),
+    ));
+  }
 
   sections
 }

--- a/src/html/util.rs
+++ b/src/html/util.rs
@@ -121,6 +121,40 @@ pub fn compute_namespaced_symbols(
           },
         ));
       }
+      DocNodeKind::TypeAlias => {
+        let type_alias_def = doc_node.type_alias_def.as_ref().unwrap();
+
+        if let Some(type_literal) = type_alias_def.ts_type.type_literal.as_ref()
+        {
+          namespaced_symbols.extend(type_literal.methods.iter().map(
+            |method| {
+              let mut method_path = current_path.to_vec();
+              method_path.extend(
+                qualify_drilldown_name(doc_node.get_name(), &method.name, true)
+                  .split('.')
+                  .map(|part| part.to_string()),
+              );
+              method_path
+            },
+          ));
+
+          namespaced_symbols.extend(type_literal.properties.iter().map(
+            |property| {
+              let mut method_path = current_path.to_vec();
+              method_path.extend(
+                qualify_drilldown_name(
+                  doc_node.get_name(),
+                  &property.name,
+                  true,
+                )
+                .split('.')
+                .map(|part| part.to_string()),
+              );
+              method_path
+            },
+          ));
+        }
+      }
       _ => {}
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -38,7 +38,9 @@ pub enum DocNodeKind {
   Variable,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(
+  Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Default,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct Location {
   pub filename: String,
@@ -153,12 +155,7 @@ impl Default for DocNode {
       kind: DocNodeKind::ModuleDoc,
       name: "".to_string(),
       declaration_kind: DeclarationKind::Private,
-      location: Location {
-        filename: "".to_string(),
-        line: 0,
-        col: 0,
-        byte_index: 0,
-      },
+      location: Location::default(),
       js_doc: JsDoc::default(),
       function_def: None,
       variable_def: None,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,7 @@ use crate::node::DeclarationKind;
 use crate::node::DocNode;
 use crate::node::ModuleDoc;
 use crate::node::NamespaceDef;
-use crate::ts_type::LiteralPropertyDef;
+use crate::ts_type::PropertyDef;
 use crate::ts_type::TsTypeDef;
 use crate::ts_type::TsTypeDefKind;
 use crate::ts_type::TsTypeLiteralDef;
@@ -1289,7 +1289,7 @@ fn parse_json_module_type(value: &serde_json::Value) -> TsTypeDef {
       type_literal: Some(TsTypeLiteralDef {
         properties: obj
           .iter()
-          .map(|(key, value)| LiteralPropertyDef {
+          .map(|(key, value)| PropertyDef {
             name: key.to_string(),
             js_doc: Default::default(),
             ts_type: Some(parse_json_module_type(value)),
@@ -1298,6 +1298,7 @@ fn parse_json_module_type(value: &serde_json::Value) -> TsTypeDef {
             computed: false,
             optional: false,
             type_params: Vec::new(),
+            location: Default::default(),
           })
           .collect(),
         ..Default::default()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -940,7 +940,12 @@ async fn json_module() {
             "methods": [],
             "properties": [{
               "name": "a",
-              "jsDoc": {},
+              "location": {
+                "filename": "",
+                "line": 0,
+                "col": 0,
+                "byteIndex": 0,
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -955,7 +960,12 @@ async fn json_module() {
               "typeParams": []
             }, {
               "name": "b",
-              "jsDoc": {},
+              "location": {
+                "filename": "",
+                "line": 0,
+                "col": 0,
+                "byteIndex": 0,
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -970,7 +980,12 @@ async fn json_module() {
               "typeParams": []
             }, {
               "name": "c",
-              "jsDoc": {},
+              "location": {
+                "filename": "",
+                "line": 0,
+                "col": 0,
+                "byteIndex": 0,
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -982,7 +997,12 @@ async fn json_module() {
               "typeParams": []
             }, {
               "name": "d",
-              "jsDoc": {},
+              "location": {
+                "filename": "",
+                "line": 0,
+                "col": 0,
+                "byteIndex": 0,
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -998,8 +1018,13 @@ async fn json_module() {
               "typeParams": []
             }, {
               "name": "e",
-              "jsDoc": {},
               "params": [],
+              "location": {
+                "filename": "",
+                "line": 0,
+                "col": 0,
+                "byteIndex": 0,
+              },
               "computed": false,
               "optional": false,
               "tsType": {
@@ -1009,7 +1034,12 @@ async fn json_module() {
                   "methods": [],
                   "properties": [{
                     "name": "a",
-                    "jsDoc": {},
+                    "location": {
+                      "filename": "",
+                      "line": 0,
+                      "col": 0,
+                      "byteIndex": 0,
+                    },
                     "params": [],
                     "computed": false,
                     "optional": false,

--- a/tests/html_test.rs
+++ b/tests/html_test.rs
@@ -209,6 +209,8 @@ async fn html_doc_files_rewrite() {
       "./index.html",
       "./~/Bar.html",
       "./~/Bar.prototype.html",
+      "./~/Baz.foo.html",
+      "./~/Baz.html",
       "./~/Foo.bar.html",
       "./~/Foo.html",
       "./~/Foo.prototype.\"><img src=x onerror=alert(1)>.html",

--- a/tests/specs/destructuring_assignment_object.txt
+++ b/tests/specs/destructuring_assignment_object.txt
@@ -55,7 +55,12 @@ private const rest
           "properties": [
             {
               "name": "a",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 1,
+                "col": 14,
+                "byteIndex": 14
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -68,7 +73,12 @@ private const rest
             },
             {
               "name": "b",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 1,
+                "col": 24,
+                "byteIndex": 24
+              },
               "params": [],
               "computed": false,
               "optional": false,

--- a/tests/specs/destructuring_assignment_object_assignment.txt
+++ b/tests/specs/destructuring_assignment_object_assignment.txt
@@ -37,7 +37,12 @@ private const obj: { a: string; b: string; }
           "properties": [
             {
               "name": "a",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 1,
+                "col": 14,
+                "byteIndex": 14
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -50,7 +55,12 @@ private const obj: { a: string; b: string; }
             },
             {
               "name": "b",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 1,
+                "col": 24,
+                "byteIndex": 24
+              },
               "params": [],
               "computed": false,
               "optional": false,

--- a/tests/specs/export_class_object_extends.txt
+++ b/tests/specs/export_class_object_extends.txt
@@ -79,7 +79,12 @@ class Bar extends obj.Foo
           "properties": [
             {
               "name": "Foo",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 2,
+                "col": 14,
+                "byteIndex": 27
+              },
               "params": [],
               "computed": false,
               "optional": false,

--- a/tests/specs/export_const_basic.txt
+++ b/tests/specs/export_const_basic.txt
@@ -165,6 +165,12 @@ const tpl2: string
                 "doc": "get doc"
               },
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 6,
+                "col": 2,
+                "byteIndex": 108
+              },
               "params": [
                 {
                   "kind": "identifier",
@@ -202,6 +208,12 @@ const tpl2: string
                 "doc": "set doc"
               },
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 9,
+                "col": 2,
+                "byteIndex": 166
+              },
               "params": [
                 {
                   "kind": "identifier",

--- a/tests/specs/export_default_interface.txt
+++ b/tests/specs/export_default_interface.txt
@@ -37,6 +37,9 @@ interface default
       "methods": [
         {
           "name": "read",
+          "jsDoc": {
+            "doc": "Read n bytes"
+          },
           "kind": "method",
           "location": {
             "filename": "file:///mod.ts",
@@ -44,10 +47,6 @@ interface default
             "col": 4,
             "byteIndex": 90
           },
-          "jsDoc": {
-            "doc": "Read n bytes"
-          },
-          "optional": true,
           "params": [
             {
               "kind": "identifier",
@@ -73,6 +72,7 @@ interface default
               }
             }
           ],
+          "optional": true,
           "returnType": {
             "repr": "Promise",
             "kind": "typeRef",

--- a/tests/specs/export_interface.txt
+++ b/tests/specs/export_interface.txt
@@ -98,6 +98,9 @@ interface Reader extends Foo, Bar
       "methods": [
         {
           "name": "read",
+          "jsDoc": {
+            "doc": "Read n bytes"
+          },
           "kind": "method",
           "location": {
             "filename": "file:///mod.ts",
@@ -105,10 +108,6 @@ interface Reader extends Foo, Bar
             "col": 4,
             "byteIndex": 135
           },
-          "jsDoc": {
-            "doc": "Read n bytes"
-          },
-          "optional": true,
           "params": [
             {
               "kind": "identifier",
@@ -134,6 +133,7 @@ interface Reader extends Foo, Bar
               }
             }
           ],
+          "optional": true,
           "returnType": {
             "repr": "Promise",
             "kind": "typeRef",

--- a/tests/specs/export_interface2.txt
+++ b/tests/specs/export_interface2.txt
@@ -50,8 +50,8 @@ interface TypedIface<T>
             "col": 4,
             "byteIndex": 37
           },
-          "optional": false,
           "params": [],
+          "optional": false,
           "returnType": {
             "repr": "T",
             "kind": "typeRef",

--- a/tests/specs/export_interface_accessors.txt
+++ b/tests/specs/export_interface_accessors.txt
@@ -66,8 +66,8 @@ interface Thing
             "col": 2,
             "byteIndex": 27
           },
-          "optional": false,
           "params": [],
+          "optional": false,
           "returnType": {
             "repr": "number",
             "kind": "keyword",
@@ -84,7 +84,6 @@ interface Thing
             "col": 2,
             "byteIndex": 49
           },
-          "optional": false,
           "params": [
             {
               "kind": "identifier",
@@ -108,6 +107,7 @@ interface Thing
               }
             }
           ],
+          "optional": false,
           "returnType": null,
           "typeParams": []
         }

--- a/tests/specs/export_type_alias_literal.txt
+++ b/tests/specs/export_type_alias_literal.txt
@@ -41,8 +41,13 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
           "methods": [
             {
               "name": "new",
-              "jsDoc": {},
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 2,
+                "col": 2,
+                "byteIndex": 20
+              },
               "params": [
                 {
                   "kind": "identifier",
@@ -68,8 +73,13 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
             },
             {
               "name": "a",
-              "jsDoc": {},
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 3,
+                "col": 2,
+                "byteIndex": 42
+              },
               "params": [],
               "optional": false,
               "returnType": {
@@ -81,8 +91,13 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
             },
             {
               "name": "b",
-              "jsDoc": {},
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 4,
+                "col": 2,
+                "byteIndex": 55
+              },
               "params": [],
               "optional": true,
               "returnType": {
@@ -94,8 +109,13 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
             },
             {
               "name": "c",
-              "jsDoc": {},
               "kind": "getter",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 5,
+                "col": 2,
+                "byteIndex": 69
+              },
               "params": [],
               "optional": false,
               "returnType": {
@@ -107,8 +127,13 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
             },
             {
               "name": "c",
-              "jsDoc": {},
               "kind": "setter",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 6,
+                "col": 2,
+                "byteIndex": 88
+              },
               "params": [
                 {
                   "kind": "identifier",

--- a/tests/specs/indented_with_tabs.txt
+++ b/tests/specs/indented_with_tabs.txt
@@ -79,14 +79,14 @@ namespace Tabs
             "properties": [
               {
                 "name": "property",
+                "jsDoc": {
+                  "doc": "Line 1\n\nLine 2\n\n\tIndented"
+                },
                 "location": {
                   "filename": "file:///mod.ts",
                   "line": 24,
                   "col": 8,
                   "byteIndex": 212
-                },
-                "jsDoc": {
-                  "doc": "Line 1\n\nLine 2\n\n\tIndented"
                 },
                 "params": [],
                 "computed": false,

--- a/tests/specs/infer_object_literal.txt
+++ b/tests/specs/infer_object_literal.txt
@@ -29,7 +29,7 @@ error[missing-jsdoc]: exported symbol is missing JSDoc documentation
 # output.txt
 Defined in file:///mod.ts:4:14
 
-const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): void; a: string; b: Map<string, number>; c: { d: string; }; f: (g: string) => void; [s]: (number | string)[]; }
+const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): void; a: string; b: Map<string, number>; c: { d: string; }; f: (g: string) => void; [[s]]: (number | string)[]; }
 
 
 # output.json
@@ -52,8 +52,13 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
           "methods": [
             {
               "name": "d",
-              "jsDoc": {},
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 8,
+                "col": 2,
+                "byteIndex": 151
+              },
               "params": [
                 {
                   "kind": "identifier",
@@ -76,8 +81,13 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "h",
-              "jsDoc": {},
               "kind": "getter",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 10,
+                "col": 2,
+                "byteIndex": 206
+              },
               "params": [],
               "optional": false,
               "returnType": {
@@ -89,8 +99,13 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "h",
-              "jsDoc": {},
               "kind": "setter",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 13,
+                "col": 2,
+                "byteIndex": 247
+              },
               "params": [
                 {
                   "kind": "identifier",
@@ -109,8 +124,13 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "[t]",
-              "jsDoc": {},
               "kind": "method",
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 17,
+                "col": 2,
+                "byteIndex": 301
+              },
               "params": [
                 {
                   "kind": "identifier",
@@ -136,7 +156,12 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
           "properties": [
             {
               "name": "a",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 5,
+                "col": 2,
+                "byteIndex": 92
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -149,7 +174,12 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "b",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 6,
+                "col": 2,
+                "byteIndex": 102
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -176,7 +206,12 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "c",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 7,
+                "col": 2,
+                "byteIndex": 134
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -188,7 +223,12 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
                   "properties": [
                     {
                       "name": "d",
-                      "jsDoc": {},
+                      "location": {
+                        "filename": "file:///mod.ts",
+                        "line": 7,
+                        "col": 7,
+                        "byteIndex": 139
+                      },
                       "params": [],
                       "computed": false,
                       "optional": false,
@@ -208,7 +248,12 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "f",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 9,
+                "col": 2,
+                "byteIndex": 176
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -241,7 +286,12 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
             },
             {
               "name": "[s]",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 16,
+                "col": 2,
+                "byteIndex": 278
+              },
               "params": [],
               "computed": true,
               "optional": false,

--- a/tests/specs/infer_object_literal_satifies.txt
+++ b/tests/specs/infer_object_literal_satifies.txt
@@ -113,7 +113,12 @@ type Colors = "red" | "green" | "blue"
           "properties": [
             {
               "name": "red",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 5,
+                "col": 4,
+                "byteIndex": 139
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -126,7 +131,12 @@ type Colors = "red" | "green" | "blue"
             },
             {
               "name": "green",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 6,
+                "col": 4,
+                "byteIndex": 157
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -139,7 +149,12 @@ type Colors = "red" | "green" | "blue"
             },
             {
               "name": "blue",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 7,
+                "col": 4,
+                "byteIndex": 177
+              },
               "params": [],
               "computed": false,
               "optional": false,
@@ -152,7 +167,12 @@ type Colors = "red" | "green" | "blue"
             },
             {
               "name": "platypus",
-              "jsDoc": {},
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 8,
+                "col": 4,
+                "byteIndex": 198
+              },
               "params": [],
               "computed": false,
               "optional": false,

--- a/tests/specs/interface_construct.txt
+++ b/tests/specs/interface_construct.txt
@@ -57,7 +57,6 @@ interface I
             "col": 2,
             "byteIndex": 23
           },
-          "optional": false,
           "params": [
             {
               "kind": "identifier",
@@ -70,6 +69,7 @@ interface I
               }
             }
           ],
+          "optional": false,
           "returnType": null,
           "typeParams": []
         }

--- a/tests/specs/interface_method.txt
+++ b/tests/specs/interface_method.txt
@@ -89,7 +89,6 @@ interface I
             "col": 2,
             "byteIndex": 23
           },
-          "optional": false,
           "params": [
             {
               "kind": "identifier",
@@ -104,6 +103,7 @@ interface I
               "tsType": null
             }
           ],
+          "optional": false,
           "returnType": null,
           "typeParams": []
         },
@@ -116,7 +116,6 @@ interface I
             "col": 2,
             "byteIndex": 34
           },
-          "optional": true,
           "params": [
             {
               "kind": "identifier",
@@ -125,6 +124,7 @@ interface I
               "tsType": null
             }
           ],
+          "optional": true,
           "returnType": null,
           "typeParams": []
         },
@@ -137,8 +137,6 @@ interface I
             "col": 2,
             "byteIndex": 44
           },
-          "computed": true,
-          "optional": false,
           "params": [
             {
               "kind": "identifier",
@@ -147,6 +145,8 @@ interface I
               "tsType": null
             }
           ],
+          "computed": true,
+          "optional": false,
           "returnType": null,
           "typeParams": []
         }

--- a/tests/specs/type_literal_index_signature.txt
+++ b/tests/specs/type_literal_index_signature.txt
@@ -37,7 +37,6 @@ type T = { [key: string]: number; }
           "callSignatures": [],
           "indexSignatures": [
             {
-              "jsDoc": {},
               "readonly": false,
               "params": [
                 {
@@ -55,6 +54,12 @@ type T = { [key: string]: number; }
                 "repr": "number",
                 "kind": "keyword",
                 "keyword": "number"
+              },
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 1,
+                "col": 18,
+                "byteIndex": 18
               }
             }
           ]

--- a/tests/specs/type_literal_readonly_index_signature.txt
+++ b/tests/specs/type_literal_readonly_index_signature.txt
@@ -37,7 +37,6 @@ type T = { readonly [key: string]: number; }
           "callSignatures": [],
           "indexSignatures": [
             {
-              "jsDoc": {},
               "readonly": true,
               "params": [
                 {
@@ -55,6 +54,12 @@ type T = { readonly [key: string]: number; }
                 "repr": "number",
                 "kind": "keyword",
                 "keyword": "number"
+              },
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 1,
+                "col": 18,
+                "byteIndex": 18
               }
             }
           ]

--- a/tests/testdata/multiple/a.ts
+++ b/tests/testdata/multiple/a.ts
@@ -37,3 +37,7 @@ export default class Foobar {
 export interface Hello {
   world: "string";
 }
+
+export type Baz = {
+  foo: string;
+};

--- a/tests/testdata/symbol_group-syntect.json
+++ b/tests/testdata/symbol_group-syntect.json
@@ -81,6 +81,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -150,6 +170,191 @@
     }
   },
   null,
+  {
+    "html_head_ctx": {
+      "title": "Baz - documentation",
+      "current_file": ".",
+      "stylesheet_url": "../styles.css",
+      "page_stylesheet_url": "../page.css",
+      "url_search_index": "../search_index.js",
+      "script_js": "../script.js",
+      "fuse_js": "../fuse.js",
+      "url_search": "../search.js"
+    },
+    "sidepanel_ctx": {
+      "partitions": [
+        {
+          "name": "Classes",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Bar",
+              "href": "../././~/Bar.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foo",
+              "href": "../././~/Foo.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foobar",
+              "href": "../././~/Foobar.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Interfaces",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Interface",
+                  "char": "I",
+                  "title": "Interface",
+                  "title_lowercase": "interface",
+                  "title_plural": "Interfaces"
+                }
+              ],
+              "name": "Hello",
+              "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": true,
+              "deprecated": false
+            }
+          ]
+        }
+      ]
+    },
+    "symbol_group_ctx": {
+      "name": "Baz",
+      "symbols": [
+        {
+          "kind": {
+            "kind": "TypeAlias",
+            "char": "T",
+            "title": "Type Alias",
+            "title_lowercase": "type alias",
+            "title_plural": "Type Aliases"
+          },
+          "tags": [],
+          "subtitle": null,
+          "content": [
+            {
+              "kind": "other",
+              "value": {
+                "id": "",
+                "docs": null,
+                "sections": [
+                  {
+                    "header": {
+                      "title": "Properties",
+                      "href": null,
+                      "doc": null
+                    },
+                    "content": {
+                      "kind": "doc_entry",
+                      "content": [
+                        {
+                          "id": "property_foo",
+                          "name": "foo",
+                          "name_href": "../././~/Baz.foo.html",
+                          "content": "<span>: <span>string</span></span>",
+                          "anchor": {
+                            "id": "property_foo"
+                          },
+                          "tags": [],
+                          "js_doc": null,
+                          "source_href": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "deprecated": null,
+          "source_href": null
+        }
+      ],
+      "usages": {
+        "usages": [
+          {
+            "name": "",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ </span><span style=\"font-weight:bold;color:#a71d5d;\">type </span><span style=\"color:#323232;\">Baz } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span></code><button class=\"context_button\" data-copy=\"import { type Baz } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "icon": null,
+            "additional_css": ""
+          }
+        ]
+      }
+    },
+    "breadcrumbs_ctx": {
+      "parts": [
+        {
+          "name": "index",
+          "href": "../",
+          "is_symbol": false,
+          "is_first_symbol": false
+        },
+        {
+          "name": "Baz",
+          "href": "../././~/Baz.html",
+          "is_symbol": true,
+          "is_first_symbol": true
+        }
+      ]
+    }
+  },
   {
     "html_head_ctx": {
       "title": "Foo - documentation",
@@ -228,6 +433,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -440,6 +665,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -587,6 +832,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -672,6 +937,197 @@
   },
   {
     "html_head_ctx": {
+      "title": "Baz.foo - documentation",
+      "current_file": ".",
+      "stylesheet_url": "../styles.css",
+      "page_stylesheet_url": "../page.css",
+      "url_search_index": "../search_index.js",
+      "script_js": "../script.js",
+      "fuse_js": "../fuse.js",
+      "url_search": "../search.js"
+    },
+    "sidepanel_ctx": {
+      "partitions": [
+        {
+          "name": "Classes",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Bar",
+              "href": "../././~/Bar.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foo",
+              "href": "../././~/Foo.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foobar",
+              "href": "../././~/Foobar.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Interfaces",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Interface",
+                  "char": "I",
+                  "title": "Interface",
+                  "title_lowercase": "interface",
+                  "title_plural": "Interfaces"
+                }
+              ],
+              "name": "Hello",
+              "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        }
+      ]
+    },
+    "symbol_group_ctx": {
+      "name": "Baz.foo",
+      "symbols": [
+        {
+          "kind": {
+            "kind": "Property",
+            "char": " ",
+            "title": "Property",
+            "title_lowercase": "property",
+            "title_plural": "Properties"
+          },
+          "tags": [],
+          "subtitle": null,
+          "content": [
+            {
+              "kind": "other",
+              "value": {
+                "id": "",
+                "docs": null,
+                "sections": [
+                  {
+                    "header": {
+                      "title": "Type",
+                      "href": null,
+                      "doc": null
+                    },
+                    "content": {
+                      "kind": "doc_entry",
+                      "content": [
+                        {
+                          "id": "variable_Baz_foo",
+                          "name": "",
+                          "name_href": null,
+                          "content": "<span>string</span>",
+                          "anchor": {
+                            "id": "variable_Baz_foo"
+                          },
+                          "tags": [],
+                          "js_doc": null,
+                          "source_href": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "deprecated": null,
+          "source_href": null
+        }
+      ],
+      "usages": {
+        "usages": [
+          {
+            "name": "",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span style=\"font-weight:bold;color:#a71d5d;\">import </span><span style=\"color:#323232;\">{ </span><span style=\"font-weight:bold;color:#a71d5d;\">type </span><span style=\"color:#323232;\">Baz } </span><span style=\"font-weight:bold;color:#a71d5d;\">from </span><span style=\"color:#183691;\">\".\"</span><span style=\"color:#323232;\">;\n</span></code><button class=\"context_button\" data-copy=\"import { type Baz } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "icon": null,
+            "additional_css": ""
+          }
+        ]
+      }
+    },
+    "breadcrumbs_ctx": {
+      "parts": [
+        {
+          "name": "index",
+          "href": "../",
+          "is_symbol": false,
+          "is_first_symbol": false
+        },
+        {
+          "name": "Baz",
+          "href": "../././~/Baz.html",
+          "is_symbol": true,
+          "is_first_symbol": true
+        },
+        {
+          "name": "foo",
+          "href": "../././~/Baz.foo.html",
+          "is_symbol": true,
+          "is_first_symbol": false
+        }
+      ]
+    }
+  },
+  {
+    "html_head_ctx": {
       "title": "Foo.bar - documentation",
       "current_file": ".",
       "stylesheet_url": "../styles.css",
@@ -748,6 +1204,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -919,6 +1395,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -1100,6 +1596,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -1273,6 +1789,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }

--- a/tests/testdata/symbol_group-tree-sitter.json
+++ b/tests/testdata/symbol_group-tree-sitter.json
@@ -81,6 +81,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -150,6 +170,191 @@
     }
   },
   null,
+  {
+    "html_head_ctx": {
+      "title": "Baz - documentation",
+      "current_file": ".",
+      "stylesheet_url": "../styles.css",
+      "page_stylesheet_url": "../page.css",
+      "url_search_index": "../search_index.js",
+      "script_js": "../script.js",
+      "fuse_js": "../fuse.js",
+      "url_search": "../search.js"
+    },
+    "sidepanel_ctx": {
+      "partitions": [
+        {
+          "name": "Classes",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Bar",
+              "href": "../././~/Bar.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foo",
+              "href": "../././~/Foo.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foobar",
+              "href": "../././~/Foobar.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Interfaces",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Interface",
+                  "char": "I",
+                  "title": "Interface",
+                  "title_lowercase": "interface",
+                  "title_plural": "Interfaces"
+                }
+              ],
+              "name": "Hello",
+              "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": true,
+              "deprecated": false
+            }
+          ]
+        }
+      ]
+    },
+    "symbol_group_ctx": {
+      "name": "Baz",
+      "symbols": [
+        {
+          "kind": {
+            "kind": "TypeAlias",
+            "char": "T",
+            "title": "Type Alias",
+            "title_lowercase": "type alias",
+            "title_plural": "Type Aliases"
+          },
+          "tags": [],
+          "subtitle": null,
+          "content": [
+            {
+              "kind": "other",
+              "value": {
+                "id": "",
+                "docs": null,
+                "sections": [
+                  {
+                    "header": {
+                      "title": "Properties",
+                      "href": null,
+                      "doc": null
+                    },
+                    "content": {
+                      "kind": "doc_entry",
+                      "content": [
+                        {
+                          "id": "property_foo",
+                          "name": "foo",
+                          "name_href": "../././~/Baz.foo.html",
+                          "content": "<span>: <span>string</span></span>",
+                          "anchor": {
+                            "id": "property_foo"
+                          },
+                          "tags": [],
+                          "js_doc": null,
+                          "source_href": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "deprecated": null,
+          "source_href": null
+        }
+      ],
+      "usages": {
+        "usages": [
+          {
+            "name": "",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { <span class=\"pl-k\">type</span> Baz } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n</code><button class=\"context_button\" data-copy=\"import { type Baz } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "icon": null,
+            "additional_css": ""
+          }
+        ]
+      }
+    },
+    "breadcrumbs_ctx": {
+      "parts": [
+        {
+          "name": "index",
+          "href": "../",
+          "is_symbol": false,
+          "is_first_symbol": false
+        },
+        {
+          "name": "Baz",
+          "href": "../././~/Baz.html",
+          "is_symbol": true,
+          "is_first_symbol": true
+        }
+      ]
+    }
+  },
   {
     "html_head_ctx": {
       "title": "Foo - documentation",
@@ -228,6 +433,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -440,6 +665,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -587,6 +832,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -672,6 +937,197 @@
   },
   {
     "html_head_ctx": {
+      "title": "Baz.foo - documentation",
+      "current_file": ".",
+      "stylesheet_url": "../styles.css",
+      "page_stylesheet_url": "../page.css",
+      "url_search_index": "../search_index.js",
+      "script_js": "../script.js",
+      "fuse_js": "../fuse.js",
+      "url_search": "../search.js"
+    },
+    "sidepanel_ctx": {
+      "partitions": [
+        {
+          "name": "Classes",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Bar",
+              "href": "../././~/Bar.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foo",
+              "href": "../././~/Foo.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foobar",
+              "href": "../././~/Foobar.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Interfaces",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Interface",
+                  "char": "I",
+                  "title": "Interface",
+                  "title_lowercase": "interface",
+                  "title_plural": "Interfaces"
+                }
+              ],
+              "name": "Hello",
+              "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        }
+      ]
+    },
+    "symbol_group_ctx": {
+      "name": "Baz.foo",
+      "symbols": [
+        {
+          "kind": {
+            "kind": "Property",
+            "char": " ",
+            "title": "Property",
+            "title_lowercase": "property",
+            "title_plural": "Properties"
+          },
+          "tags": [],
+          "subtitle": null,
+          "content": [
+            {
+              "kind": "other",
+              "value": {
+                "id": "",
+                "docs": null,
+                "sections": [
+                  {
+                    "header": {
+                      "title": "Type",
+                      "href": null,
+                      "doc": null
+                    },
+                    "content": {
+                      "kind": "doc_entry",
+                      "content": [
+                        {
+                          "id": "variable_Baz_foo",
+                          "name": "",
+                          "name_href": null,
+                          "content": "<span>string</span>",
+                          "anchor": {
+                            "id": "variable_Baz_foo"
+                          },
+                          "tags": [],
+                          "js_doc": null,
+                          "source_href": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "deprecated": null,
+          "source_href": null
+        }
+      ],
+      "usages": {
+        "usages": [
+          {
+            "name": "",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code><span class=\"pl-k\">import</span> { <span class=\"pl-k\">type</span> Baz } <span class=\"pl-k\">from</span> <span class=\"pl-s\">\".\"</span>;\n</code><button class=\"context_button\" data-copy=\"import { type Baz } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "icon": null,
+            "additional_css": ""
+          }
+        ]
+      }
+    },
+    "breadcrumbs_ctx": {
+      "parts": [
+        {
+          "name": "index",
+          "href": "../",
+          "is_symbol": false,
+          "is_first_symbol": false
+        },
+        {
+          "name": "Baz",
+          "href": "../././~/Baz.html",
+          "is_symbol": true,
+          "is_first_symbol": true
+        },
+        {
+          "name": "foo",
+          "href": "../././~/Baz.foo.html",
+          "is_symbol": true,
+          "is_first_symbol": false
+        }
+      ]
+    }
+  },
+  {
+    "html_head_ctx": {
       "title": "Foo.bar - documentation",
       "current_file": ".",
       "stylesheet_url": "../styles.css",
@@ -748,6 +1204,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -919,6 +1395,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -1100,6 +1596,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -1273,6 +1789,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }

--- a/tests/testdata/symbol_group.json
+++ b/tests/testdata/symbol_group.json
@@ -81,6 +81,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -150,6 +170,191 @@
     }
   },
   null,
+  {
+    "html_head_ctx": {
+      "title": "Baz - documentation",
+      "current_file": ".",
+      "stylesheet_url": "../styles.css",
+      "page_stylesheet_url": "../page.css",
+      "url_search_index": "../search_index.js",
+      "script_js": "../script.js",
+      "fuse_js": "../fuse.js",
+      "url_search": "../search.js"
+    },
+    "sidepanel_ctx": {
+      "partitions": [
+        {
+          "name": "Classes",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Bar",
+              "href": "../././~/Bar.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foo",
+              "href": "../././~/Foo.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foobar",
+              "href": "../././~/Foobar.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Interfaces",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Interface",
+                  "char": "I",
+                  "title": "Interface",
+                  "title_lowercase": "interface",
+                  "title_plural": "Interfaces"
+                }
+              ],
+              "name": "Hello",
+              "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": true,
+              "deprecated": false
+            }
+          ]
+        }
+      ]
+    },
+    "symbol_group_ctx": {
+      "name": "Baz",
+      "symbols": [
+        {
+          "kind": {
+            "kind": "TypeAlias",
+            "char": "T",
+            "title": "Type Alias",
+            "title_lowercase": "type alias",
+            "title_plural": "Type Aliases"
+          },
+          "tags": [],
+          "subtitle": null,
+          "content": [
+            {
+              "kind": "other",
+              "value": {
+                "id": "",
+                "docs": null,
+                "sections": [
+                  {
+                    "header": {
+                      "title": "Properties",
+                      "href": null,
+                      "doc": null
+                    },
+                    "content": {
+                      "kind": "doc_entry",
+                      "content": [
+                        {
+                          "id": "property_foo",
+                          "name": "foo",
+                          "name_href": "../././~/Baz.foo.html",
+                          "content": "<span>: <span>string</span></span>",
+                          "anchor": {
+                            "id": "property_foo"
+                          },
+                          "tags": [],
+                          "js_doc": null,
+                          "source_href": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "deprecated": null,
+          "source_href": null
+        }
+      ],
+      "usages": {
+        "usages": [
+          {
+            "name": "",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { type Baz } from \".\";\n</code><button class=\"context_button\" data-copy=\"import { type Baz } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "icon": null,
+            "additional_css": ""
+          }
+        ]
+      }
+    },
+    "breadcrumbs_ctx": {
+      "parts": [
+        {
+          "name": "index",
+          "href": "../",
+          "is_symbol": false,
+          "is_first_symbol": false
+        },
+        {
+          "name": "Baz",
+          "href": "../././~/Baz.html",
+          "is_symbol": true,
+          "is_first_symbol": true
+        }
+      ]
+    }
+  },
   {
     "html_head_ctx": {
       "title": "Foo - documentation",
@@ -228,6 +433,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -440,6 +665,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -587,6 +832,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -672,6 +937,197 @@
   },
   {
     "html_head_ctx": {
+      "title": "Baz.foo - documentation",
+      "current_file": ".",
+      "stylesheet_url": "../styles.css",
+      "page_stylesheet_url": "../page.css",
+      "url_search_index": "../search_index.js",
+      "script_js": "../script.js",
+      "fuse_js": "../fuse.js",
+      "url_search": "../search.js"
+    },
+    "sidepanel_ctx": {
+      "partitions": [
+        {
+          "name": "Classes",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Bar",
+              "href": "../././~/Bar.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foo",
+              "href": "../././~/Foo.html",
+              "active": false,
+              "deprecated": false
+            },
+            {
+              "kind": [
+                {
+                  "kind": "Class",
+                  "char": "c",
+                  "title": "Class",
+                  "title_lowercase": "class",
+                  "title_plural": "Classes"
+                }
+              ],
+              "name": "Foobar",
+              "href": "../././~/Foobar.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Interfaces",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "Interface",
+                  "char": "I",
+                  "title": "Interface",
+                  "title_lowercase": "interface",
+                  "title_plural": "Interfaces"
+                }
+              ],
+              "name": "Hello",
+              "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        }
+      ]
+    },
+    "symbol_group_ctx": {
+      "name": "Baz.foo",
+      "symbols": [
+        {
+          "kind": {
+            "kind": "Property",
+            "char": " ",
+            "title": "Property",
+            "title_lowercase": "property",
+            "title_plural": "Properties"
+          },
+          "tags": [],
+          "subtitle": null,
+          "content": [
+            {
+              "kind": "other",
+              "value": {
+                "id": "",
+                "docs": null,
+                "sections": [
+                  {
+                    "header": {
+                      "title": "Type",
+                      "href": null,
+                      "doc": null
+                    },
+                    "content": {
+                      "kind": "doc_entry",
+                      "content": [
+                        {
+                          "id": "variable_Baz_foo",
+                          "name": "",
+                          "name_href": null,
+                          "content": "<span>string</span>",
+                          "anchor": {
+                            "id": "variable_Baz_foo"
+                          },
+                          "tags": [],
+                          "js_doc": null,
+                          "source_href": null
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "deprecated": null,
+          "source_href": null
+        }
+      ],
+      "usages": {
+        "usages": [
+          {
+            "name": "",
+            "content": "<div class=\"markdown flex-1\"><pre class=\"highlight\"><code>import { type Baz } from \".\";\n</code><button class=\"context_button\" data-copy=\"import { type Baz } from &quot;.&quot;;\n\"><svg width=\"15\" height=\"15\" viewBox=\"0 0 15 15\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n  <path d=\"M1.55566 2.7C1.55566 2.03726 2.09292 1.5 2.75566 1.5H8.75566C9.41841 1.5 9.95566 2.03726 9.95566 2.7V5.1H12.3557C13.0184 5.1 13.5557 5.63726 13.5557 6.3V12.3C13.5557 12.9627 13.0184 13.5 12.3557 13.5H6.35566C5.69292 13.5 5.15566 12.9627 5.15566 12.3V9.9H2.75566C2.09292 9.9 1.55566 9.36274 1.55566 8.7V2.7ZM6.35566 9.9V12.3H12.3557V6.3H9.95566V8.7C9.95566 9.36274 9.41841 9.9 8.75566 9.9H6.35566ZM8.75566 8.7V2.7L2.75566 2.7V8.7H8.75566Z\" fill=\"#232323\"></path>\n</svg>\n</button><code></code></pre>\n</div>",
+            "icon": null,
+            "additional_css": ""
+          }
+        ]
+      }
+    },
+    "breadcrumbs_ctx": {
+      "parts": [
+        {
+          "name": "index",
+          "href": "../",
+          "is_symbol": false,
+          "is_first_symbol": false
+        },
+        {
+          "name": "Baz",
+          "href": "../././~/Baz.html",
+          "is_symbol": true,
+          "is_first_symbol": true
+        },
+        {
+          "name": "foo",
+          "href": "../././~/Baz.foo.html",
+          "is_symbol": true,
+          "is_first_symbol": false
+        }
+      ]
+    }
+  },
+  {
+    "html_head_ctx": {
       "title": "Foo.bar - documentation",
       "current_file": ".",
       "stylesheet_url": "../styles.css",
@@ -748,6 +1204,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -919,6 +1395,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }
@@ -1100,6 +1596,26 @@
               "deprecated": false
             }
           ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
         }
       ]
     },
@@ -1273,6 +1789,26 @@
               ],
               "name": "Hello",
               "href": "../././~/Hello.html",
+              "active": false,
+              "deprecated": false
+            }
+          ]
+        },
+        {
+          "name": "Type Aliases",
+          "symbols": [
+            {
+              "kind": [
+                {
+                  "kind": "TypeAlias",
+                  "char": "T",
+                  "title": "Type Alias",
+                  "title_lowercase": "type alias",
+                  "title_plural": "Type Aliases"
+                }
+              ],
+              "name": "Baz",
+              "href": "../././~/Baz.html",
               "active": false,
               "deprecated": false
             }

--- a/tests/testdata/symbol_search.json
+++ b/tests/testdata/symbol_search.json
@@ -62,6 +62,21 @@
     },
     {
       "kind": [
+        "typeAlias"
+      ],
+      "name": "Baz",
+      "file": ".",
+      "location": {
+        "filename": "default",
+        "line": 41,
+        "col": 0,
+        "byteIndex": 705
+      },
+      "declarationKind": "export",
+      "deprecated": false
+    },
+    {
+      "kind": [
         "function"
       ],
       "name": "x",


### PR DESCRIPTION
To reduce complexity, `LiteralMethodDef` and related are stripped the `Literal` prefix, and are used for interfaces as well as they now have identical structure. IndexSignature get the same treatment, but additionally also applies to classes.