### PR TITLE
feat: separate constructors from methods for type literals and interfaces

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -510,6 +510,18 @@ impl<'a, 'b> DiagnosticDocNodeVisitor<'a, 'b> {
   }
 
   fn visit_interface_def(&mut self, def: &crate::interface::InterfaceDef) {
+    // constructors
+    for constructor in &def.constructors {
+      self
+        .diagnostics
+        .check_missing_js_doc(&constructor.js_doc, &constructor.location);
+      self.diagnostics.check_missing_return_type(
+        constructor.return_type.as_ref(),
+        &constructor.js_doc,
+        &constructor.location,
+      );
+    }
+
     // properties
     for prop in &def.properties {
       self

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -24,6 +24,7 @@ pub struct InterfaceDef {
   /// set when the interface is a default export
   pub def_name: Option<String>,
   pub extends: Vec<TsTypeDef>,
+  #[serde(default)]
   pub constructors: Vec<ConstructorDef>,
   pub methods: Vec<MethodDef>,
   pub properties: Vec<PropertyDef>,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 use crate::params::ts_fn_param_to_param_def;
 use crate::ts_type::CallSignatureDef;
+use crate::ts_type::ConstructorDef;
 use crate::ts_type::IndexSignatureDef;
 use crate::ts_type::MethodDef;
 use crate::ts_type::PropertyDef;
@@ -23,6 +24,7 @@ pub struct InterfaceDef {
   /// set when the interface is a default export
   pub def_name: Option<String>,
   pub extends: Vec<TsTypeDef>,
+  pub constructors: Vec<ConstructorDef>,
   pub methods: Vec<MethodDef>,
   pub properties: Vec<PropertyDef>,
   pub call_signatures: Vec<CallSignatureDef>,
@@ -78,6 +80,7 @@ pub fn get_doc_for_ts_interface_decl(
 ) -> (String, InterfaceDef) {
   let interface_name = interface_decl.id.sym.to_string();
 
+  let mut constructors = vec![];
   let mut methods = vec![];
   let mut properties = vec![];
   let mut call_signatures = vec![];
@@ -266,7 +269,7 @@ pub fn get_doc_for_ts_interface_decl(
         }
       }
       TsConstructSignatureDecl(ts_construct_sig) => {
-        if let Some(construct_js_doc) =
+        if let Some(js_doc) =
           js_doc_for_range(parsed_source, &ts_construct_sig.range())
         {
           let mut params = vec![];
@@ -286,19 +289,15 @@ pub fn get_doc_for_ts_interface_decl(
             .as_ref()
             .map(|rt| TsTypeDef::new(parsed_source, &rt.type_ann));
 
-          let construct_sig_def = MethodDef {
-            name: "new".to_string(),
-            kind: deno_ast::swc::ast::MethodKind::Method,
-            js_doc: construct_js_doc,
+          let construct_sig_def = ConstructorDef {
+            js_doc,
             location: get_location(parsed_source, ts_construct_sig.start()),
-            computed: false,
-            optional: false,
             params,
             return_type: maybe_return_type,
             type_params,
           };
 
-          methods.push(construct_sig_def);
+          constructors.push(construct_sig_def);
         }
       }
     }
@@ -318,6 +317,7 @@ pub fn get_doc_for_ts_interface_decl(
   let interface_def = InterfaceDef {
     def_name,
     extends,
+    constructors,
     methods,
     properties,
     call_signatures,

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -463,6 +463,10 @@ impl<'a> DocPrinter<'a> {
   ) -> FmtResult {
     let interface_def = node.interface_def.as_ref().unwrap();
 
+    for constructor in &interface_def.constructors {
+      writeln!(w, "{}{}", Indent(1), constructor)?;
+      self.format_jsdoc(w, &constructor.js_doc, 2)?;
+    }
     for property_def in &interface_def.properties {
       writeln!(w, "{}{}", Indent(1), property_def)?;
       self.format_jsdoc(w, &property_def.js_doc, 2)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -358,6 +358,7 @@ export { Hello } from "./reexport.ts";
       "declarationKind": "export",
       "interfaceDef": {
         "extends": [],
+        "constructors": [],
         "methods": [],
         "properties": [],
         "callSignatures": [],
@@ -937,6 +938,7 @@ async fn json_module() {
           "repr": "",
           "kind": "typeLiteral",
           "typeLiteral": {
+            "constructors": [],
             "methods": [],
             "properties": [{
               "name": "a",
@@ -1031,6 +1033,7 @@ async fn json_module() {
                 "repr": "",
                 "kind": "typeLiteral",
                 "typeLiteral": {
+                  "constructors": [],
                   "methods": [],
                   "properties": [{
                     "name": "a",

--- a/src/ts_type.rs
+++ b/src/ts_type.rs
@@ -1101,6 +1101,7 @@ impl Display for IndexSignatureDef {
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TsTypeLiteralDef {
+  #[serde(default)]
   pub constructors: Vec<ConstructorDef>,
   pub methods: Vec<MethodDef>,
   pub properties: Vec<PropertyDef>,

--- a/tests/specs/Jsdoc.txt
+++ b/tests/specs/Jsdoc.txt
@@ -85,6 +85,7 @@ interface B
     },
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/destructuring_assignment_object.txt
+++ b/tests/specs/destructuring_assignment_object.txt
@@ -51,6 +51,7 @@ private const rest
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [
             {

--- a/tests/specs/destructuring_assignment_object_assignment.txt
+++ b/tests/specs/destructuring_assignment_object_assignment.txt
@@ -33,6 +33,7 @@ private const obj: { a: string; b: string; }
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [
             {

--- a/tests/specs/export_class_object_extends.txt
+++ b/tests/specs/export_class_object_extends.txt
@@ -75,6 +75,7 @@ class Bar extends obj.Foo
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [
             {

--- a/tests/specs/export_const_basic.txt
+++ b/tests/specs/export_const_basic.txt
@@ -158,6 +158,7 @@ const tpl2: string
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [
             {
               "name": "get",

--- a/tests/specs/export_default_interface.txt
+++ b/tests/specs/export_default_interface.txt
@@ -34,6 +34,7 @@ interface default
     "interfaceDef": {
       "defName": "Reader",
       "extends": [],
+      "constructors": [],
       "methods": [
         {
           "name": "read",

--- a/tests/specs/export_fn2.txt
+++ b/tests/specs/export_fn2.txt
@@ -170,6 +170,7 @@ private interface AssignOpts
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [
         {

--- a/tests/specs/export_interface.txt
+++ b/tests/specs/export_interface.txt
@@ -95,6 +95,7 @@ interface Reader extends Foo, Bar
           }
         }
       ],
+      "constructors": [],
       "methods": [
         {
           "name": "read",
@@ -199,6 +200,7 @@ interface Reader extends Foo, Bar
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],
@@ -218,6 +220,7 @@ interface Reader extends Foo, Bar
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/export_interface2.txt
+++ b/tests/specs/export_interface2.txt
@@ -40,6 +40,7 @@ interface TypedIface<T>
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [
         {
           "name": "something",

--- a/tests/specs/export_interface_accessors.txt
+++ b/tests/specs/export_interface_accessors.txt
@@ -56,6 +56,7 @@ interface Thing
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [
         {
           "name": "size",

--- a/tests/specs/export_type_alias_literal.txt
+++ b/tests/specs/export_type_alias_literal.txt
@@ -18,7 +18,7 @@ error[missing-jsdoc]: exported symbol is missing JSDoc documentation
 # output.txt
 Defined in file:///mod.ts:1:1
 
-type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); }
+type A = { a(): void; b?(): void; c(): string; c(v: number); }
 
 
 # output.json
@@ -38,16 +38,8 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
-          "methods": [
+          "constructors": [
             {
-              "name": "new",
-              "kind": "method",
-              "location": {
-                "filename": "file:///mod.ts",
-                "line": 2,
-                "col": 2,
-                "byteIndex": 20
-              },
               "params": [
                 {
                   "kind": "identifier",
@@ -60,7 +52,6 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
                   }
                 }
               ],
-              "optional": false,
               "returnType": {
                 "repr": "A",
                 "kind": "typeRef",
@@ -69,8 +60,16 @@ type A = { new(d: string): A; a(): void; b?(): void; c(): string; c(v: number); 
                   "typeName": "A"
                 }
               },
-              "typeParams": []
-            },
+              "typeParams": [],
+              "location": {
+                "filename": "file:///mod.ts",
+                "line": 2,
+                "col": 2,
+                "byteIndex": 20
+              }
+            }
+          ],
+          "methods": [
             {
               "name": "a",
               "kind": "method",

--- a/tests/specs/exports_all_with_private.txt
+++ b/tests/specs/exports_all_with_private.txt
@@ -137,6 +137,7 @@ private namespace H
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],
@@ -215,6 +216,7 @@ private namespace H
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/generic_instantiated_with_tuple_type.txt
+++ b/tests/specs/generic_instantiated_with_tuple_type.txt
@@ -42,6 +42,7 @@ interface Generic<T>
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/import_equals.txt
+++ b/tests/specs/import_equals.txt
@@ -37,6 +37,7 @@ interface Options
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/indented_with_tabs.txt
+++ b/tests/specs/indented_with_tabs.txt
@@ -75,6 +75,7 @@ namespace Tabs
           },
           "interfaceDef": {
             "extends": [],
+            "constructors": [],
             "methods": [],
             "properties": [
               {

--- a/tests/specs/infer_object_literal.txt
+++ b/tests/specs/infer_object_literal.txt
@@ -49,6 +49,7 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [
             {
               "name": "d",
@@ -219,6 +220,7 @@ const a: { d(e: string): void; h(): string; h(value: string); [[t]](u: string): 
                 "repr": "",
                 "kind": "typeLiteral",
                 "typeLiteral": {
+                  "constructors": [],
                   "methods": [],
                   "properties": [
                     {

--- a/tests/specs/infer_object_literal_satifies.txt
+++ b/tests/specs/infer_object_literal_satifies.txt
@@ -109,6 +109,7 @@ type Colors = "red" | "green" | "blue"
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [
             {

--- a/tests/specs/interface_construct.txt
+++ b/tests/specs/interface_construct.txt
@@ -11,26 +11,11 @@ error[missing-jsdoc]: exported symbol is missing JSDoc documentation
   | ^
 
 
-error[missing-jsdoc]: exported symbol is missing JSDoc documentation
- --> /mod.ts:2:3
-  | 
-2 |   new(name: string);
-  |   ^
-
-
-error[missing-return-type]: exported function is missing an explicit return type annotation
- --> /mod.ts:2:3
-  | 
-2 |   new(name: string);
-  |   ^
-
-
 # output.txt
 Defined in file:///mod.ts:1:1
 
 interface I
 
-  new(name: string)
 
 
 # output.json
@@ -47,16 +32,8 @@ interface I
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
-      "methods": [
+      "constructors": [
         {
-          "name": "new",
-          "kind": "method",
-          "location": {
-            "filename": "file:///mod.ts",
-            "line": 2,
-            "col": 2,
-            "byteIndex": 23
-          },
           "params": [
             {
               "kind": "identifier",
@@ -69,11 +46,17 @@ interface I
               }
             }
           ],
-          "optional": false,
           "returnType": null,
-          "typeParams": []
+          "typeParams": [],
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 2,
+            "col": 2,
+            "byteIndex": 23
+          }
         }
       ],
+      "methods": [],
       "properties": [],
       "callSignatures": [],
       "indexSignatures": [],

--- a/tests/specs/interface_construct.txt
+++ b/tests/specs/interface_construct.txt
@@ -11,11 +11,26 @@ error[missing-jsdoc]: exported symbol is missing JSDoc documentation
   | ^
 
 
+error[missing-jsdoc]: exported symbol is missing JSDoc documentation
+ --> /mod.ts:2:3
+  | 
+2 |   new(name: string);
+  |   ^
+
+
+error[missing-return-type]: exported function is missing an explicit return type annotation
+ --> /mod.ts:2:3
+  | 
+2 |   new(name: string);
+  |   ^
+
+
 # output.txt
 Defined in file:///mod.ts:1:1
 
 interface I
 
+  constructor(name: string)
 
 
 # output.json

--- a/tests/specs/interface_declaration.txt
+++ b/tests/specs/interface_declaration.txt
@@ -30,6 +30,7 @@ interface Interface
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_extends.txt
+++ b/tests/specs/interface_extends.txt
@@ -39,6 +39,7 @@ interface Interface extends Iterator
           }
         }
       ],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_extends2.txt
+++ b/tests/specs/interface_extends2.txt
@@ -47,6 +47,7 @@ interface Interface extends Iterator, Iterable
           }
         }
       ],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_generic.txt
+++ b/tests/specs/interface_generic.txt
@@ -30,6 +30,7 @@ interface Interface<T>
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_generic_extends.txt
+++ b/tests/specs/interface_generic_extends.txt
@@ -48,6 +48,7 @@ interface Interface<V> extends Iterable<V>
           }
         }
       ],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_index_signature.txt
+++ b/tests/specs/interface_index_signature.txt
@@ -40,6 +40,7 @@ interface Interface
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_method.txt
+++ b/tests/specs/interface_method.txt
@@ -79,6 +79,7 @@ interface I
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [
         {
           "name": "m",

--- a/tests/specs/interface_number_literal_property.txt
+++ b/tests/specs/interface_number_literal_property.txt
@@ -49,6 +49,7 @@ interface I
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [
         {

--- a/tests/specs/interface_property.txt
+++ b/tests/specs/interface_property.txt
@@ -67,6 +67,7 @@ interface I
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [
         {

--- a/tests/specs/interface_readonly_index_signature.txt
+++ b/tests/specs/interface_readonly_index_signature.txt
@@ -40,6 +40,7 @@ interface Interface
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/interface_string_literal_property.txt
+++ b/tests/specs/interface_string_literal_property.txt
@@ -49,6 +49,7 @@ interface I
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [
         {

--- a/tests/specs/private_type_implementation_signature.txt
+++ b/tests/specs/private_type_implementation_signature.txt
@@ -187,6 +187,7 @@ namespace SameName
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],
@@ -206,6 +207,7 @@ namespace SameName
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/private_type_in_namespace.txt
+++ b/tests/specs/private_type_in_namespace.txt
@@ -76,6 +76,7 @@ private namespace Test
     "declarationKind": "export",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [
         {

--- a/tests/specs/private_type_private_member.txt
+++ b/tests/specs/private_type_private_member.txt
@@ -152,6 +152,7 @@ private interface YesDiagnostic
     "declarationKind": "private",
     "interfaceDef": {
       "extends": [],
+      "constructors": [],
       "methods": [],
       "properties": [],
       "callSignatures": [],

--- a/tests/specs/type_literal_declaration.txt
+++ b/tests/specs/type_literal_declaration.txt
@@ -32,6 +32,7 @@ type T = { }
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [],
           "callSignatures": [],

--- a/tests/specs/type_literal_index_signature.txt
+++ b/tests/specs/type_literal_index_signature.txt
@@ -32,6 +32,7 @@ type T = { [key: string]: number; }
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [],
           "callSignatures": [],

--- a/tests/specs/type_literal_readonly_index_signature.txt
+++ b/tests/specs/type_literal_readonly_index_signature.txt
@@ -32,6 +32,7 @@ type T = { readonly [key: string]: number; }
         "repr": "",
         "kind": "typeLiteral",
         "typeLiteral": {
+          "constructors": [],
           "methods": [],
           "properties": [],
           "callSignatures": [],


### PR DESCRIPTION
having constructors be methods called `new` makes it difficult for the html generator to render in a proper manner. example of problem when being a method:
![image](https://github.com/denoland/deno_doc/assets/13135287/ccc226c4-07d6-4796-b2da-b9613c2c34ef)

one option would be to instead separate methods that called `new` in the html, but doesnt seem desirable, especially as that wouldnt separate between actual method called `new` and constructors.