### PR TITLE
fix: all symbols summary and example title

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,7 @@
     "test": "deno test -A",
     "tailwind": "deno run -A build_css.ts",
     "gen_html": "deno task tailwind && cargo run --example ddoc --features=html -- --name \"std HTTP and Assert\" --html ../deno_std/http/mod.ts ../deno_std/assert/mod.ts ../deno_std/collections/mod.ts --output generated_docs/ --main_entrypoint ../deno_std/assert/mod.ts",
-    "test:update": "UPDATE=1 cargo test --locked --all-targets && UPDATE=1 cargo test --locked --all-targets --features=tree-sitter && UPDATE=1 cargo test --locked --all-targets --features=syntect"
+    "test:update": "UPDATE=1 cargo test --locked --all-targets && UPDATE=1 cargo test --locked --all-targets --features=tree-sitter && UPDATE=1 cargo test --locked --all-targets --features=syntect && cargo insta test --review"
   },
   "exclude": [
     "target",

--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -389,7 +389,7 @@ pub(crate) fn render_markdown_summary(
     md,
     MarkdownToHTMLOptions {
       summary: true,
-      summary_prefer_title: false,
+      summary_prefer_title: true,
     },
   )
   .unwrap_or_default()
@@ -418,7 +418,7 @@ pub(crate) fn jsdoc_body_to_html(
       doc,
       MarkdownToHTMLOptions {
         summary,
-        summary_prefer_title: false,
+        summary_prefer_title: true,
       },
     )
   } else {

--- a/tests/snapshots/html_test__html_doc_files_rewrite-16.snap
+++ b/tests/snapshots/html_test__html_doc_files_rewrite-16.snap
@@ -115,7 +115,8 @@ Classes</h2></div><div class="namespaceSection"><div class="namespaceItem" ><div
 <div class="namespaceItemContent">
 		    <a href="..&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html" title="Foo">Foo</a>
 
-	      <div><span class="italic">No documentation available</span></div>
+	      <div><div class="markdown_summary"><p>some Foo docs</p>
+</div></div>
       </div>
     </div><div class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Class bg-Class/15" title="Class">c</div></div>
 <div class="namespaceItemContent">

--- a/tests/snapshots/html_test__html_doc_files_rewrite.snap
+++ b/tests/snapshots/html_test__html_doc_files_rewrite.snap
@@ -75,7 +75,8 @@ expression: "files.get(\"./all_symbols.html\").unwrap()"
 <div class="namespaceItemContent">
 		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html" title="Foo">Foo</a>
 
-	      <div><span class="italic">No documentation available</span></div>
+	      <div><div class="markdown_summary"><p>some Foo docs</p>
+</div></div>
       </div>
     </div><div class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Class bg-Class/15" title="Class">c</div></div>
 <div class="namespaceItemContent">


### PR DESCRIPTION
fixes #565

This PR changes the rendering of 'All symbols' page of local `deno_std/bytes/mod.ts`  like the below (using the command `cargo run --example ddoc ../deno_std/bytes/mod.ts --html --output public`):

BEFORE
<img width="1295" alt="Screenshot 2024-05-08 at 21 08 50" src="https://github.com/denoland/deno_doc/assets/613956/46c7d720-173f-4db9-a4c4-f8a4e3e54a13">

AFTER
<img width="1306" alt="Screenshot 2024-05-08 at 21 08 26" src="https://github.com/denoland/deno_doc/assets/613956/34b7e5b5-9602-4103-af08-cd9b8e37904b">

Also changes the rendering of `@example` tag in API page like the below:

BEFORE
<img width="999" alt="Screenshot 2024-05-08 at 21 09 28" src="https://github.com/denoland/deno_doc/assets/613956/7ca4142a-8a2b-48af-872e-5ddcaf066054">

AFTER
<img width="998" alt="Screenshot 2024-05-08 at 21 09 52" src="https://github.com/denoland/deno_doc/assets/613956/a58569f6-9e4b-4b20-a6cc-274d4704eb7c">
