### PR TITLE
fix(cli): fix stack overflow in Deno doc when namespace exports itself

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -580,6 +580,10 @@ impl<'a> DocParser<'a> {
     let mut handled_symbols = HashSet::new();
 
     for (export_name, export_symbol_id) in symbol.exports() {
+      if export_name == &namespace_name
+      {
+        continue;
+      }
       handled_symbols.insert(UniqueSymbolId::new(
         module_info.module_id(),
         *export_symbol_id,


### PR DESCRIPTION
This PR fixes: https://github.com/denoland/deno/issues/23711


When executing `deno doc` on a TypeScript file that contains a namespace exporting itself, like in this file example:
https://gist.github.com/crowlKats/1f6ed084bbab0a10267df9ed31564599
```
export namespace test {
    export { test };
}
```
The program exits with the following error:
 **thread 'main' has overflowed its stack
error: process didn't exit successfully: `target\debug\examples\ddoc.exe test3.d.ts` (exit code: 0xc00000fd, STATUS_STACK_OVERFLOW)**

Solution:
I added a check to see if the export is the same as the namespace and, if so, it ignores generating the `DocNode` for it.


