### PR TITLE
feat(html): external jsdoc module linking

### DIFF
--- a/examples/ddoc/main.rs
+++ b/examples/ddoc/main.rs
@@ -203,6 +203,14 @@ impl HrefResolver for EmptyResolver {
   fn resolve_source(&self, location: &deno_doc::Location) -> Option<String> {
     Some(location.filename.to_string())
   }
+
+  fn resolve_external_jsdoc_module(
+    &self,
+    _module: &str,
+    _symbol: Option<&str>,
+  ) -> Option<(String, String)> {
+    None
+  }
 }
 
 fn generate_docs_directory(

--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -155,6 +155,14 @@ fn parse_links<'a>(md: &'a str, ctx: &RenderContext) -> Cow<'a, str> {
             title = short_path.display_name().to_string();
           }
         }
+      } else if let Some((external_link, external_title)) =
+        ctx.ctx.href_resolver.resolve_external_jsdoc_module(
+          module_link,
+          symbol_match.map(|symbol_match| symbol_match.as_str()),
+        )
+      {
+        link = external_link;
+        title = external_title;
       }
 
       link
@@ -766,6 +774,14 @@ mod test {
 
     fn resolve_source(&self, _location: &Location) -> Option<String> {
       None
+    }
+
+    fn resolve_external_jsdoc_module(
+      &self,
+      module: &str,
+      symbol: Option<&str>,
+    ) -> Option<(String, String)> {
+      todo!()
     }
   }
 

--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -778,10 +778,10 @@ mod test {
 
     fn resolve_external_jsdoc_module(
       &self,
-      module: &str,
-      symbol: Option<&str>,
+      _module: &str,
+      _symbol: Option<&str>,
     ) -> Option<(String, String)> {
-      todo!()
+      None
     }
   }
 

--- a/src/html/render_context.rs
+++ b/src/html/render_context.rs
@@ -398,6 +398,14 @@ mod test {
     fn resolve_source(&self, location: &Location) -> Option<String> {
       Some(location.filename.clone().into_string())
     }
+
+    fn resolve_external_jsdoc_module(
+      &self,
+      _module: &str,
+      _symbol: Option<&str>,
+    ) -> Option<(String, String)> {
+      None
+    }
   }
 
   #[test]

--- a/src/html/util.rs
+++ b/src/html/util.rs
@@ -316,6 +316,14 @@ pub trait HrefResolver {
 
   /// Resolve the URL used in source code link buttons.
   fn resolve_source(&self, location: &crate::Location) -> Option<String>;
+
+  /// Resolve external JSDoc module links.
+  /// Returns a tuple with link and title.
+  fn resolve_external_jsdoc_module(
+    &self,
+    module: &str,
+    symbol: Option<&str>,
+  ) -> Option<(String, String)>;
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/tests/html_test.rs
+++ b/tests/html_test.rs
@@ -77,6 +77,14 @@ impl HrefResolver for EmptyResolver {
   fn resolve_source(&self, _location: &deno_doc::Location) -> Option<String> {
     None
   }
+
+  fn resolve_external_jsdoc_module(
+    &self,
+    _module: &str,
+    _symbol: Option<&str>,
+  ) -> Option<(String, String)> {
+    None
+  }
 }
 
 async fn get_files(subpath: &str) -> IndexMap<ModuleSpecifier, Vec<DocNode>> {


### PR DESCRIPTION
Follow-up for #586, adding an external linking callback