### PR TITLE
test: separate test case which require sanitizer disabled

### DIFF
--- a/js/allow_leak_test.ts
+++ b/js/allow_leak_test.ts
@@ -1,0 +1,19 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertRejects } from "jsr:@std/assert@0.223";
+import { doc } from "./mod.ts";
+
+Deno.test({
+  name: "doc() - missing specifier",
+  // TODO(@kitsonk) - remove when new deno_graph crate published
+  sanitizeResources: false,
+  async fn() {
+    await assertRejects(
+      async () => {
+        await doc("https://deno.land/x/bad.ts");
+      },
+      Error,
+      `Module not found "https://deno.land/x/bad.ts".`,
+    );
+  },
+});

--- a/js/test.ts
+++ b/js/test.ts
@@ -77,21 +77,6 @@ Deno.test({
 });
 
 Deno.test({
-  name: "doc() - missing specifier",
-  // TODO(@kitsonk) - remove when new deno_graph crate published
-  sanitizeResources: false,
-  async fn() {
-    await assertRejects(
-      async () => {
-        await doc("https://deno.land/x/bad.ts");
-      },
-      Error,
-      `Module not found "https://deno.land/x/bad.ts".`,
-    );
-  },
-});
-
-Deno.test({
   name: "doc() - bad specifier",
   async fn() {
     await assertRejects(


### PR DESCRIPTION
This PR separate a test case with sanitizer disabled into a file next to it.

The test cases with sanitizer enabled and disabled can't be mixed because of this issue https://github.com/denoland/deno/issues/22927

Currently the windows CI is flaky because of this issue.