### PR TITLE
fix: ensure safe text slicing boundaries with multi-byte characters

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -110,13 +110,21 @@ impl Diagnostic for DocDiagnostic {
   }
 
   fn snippet(&self) -> Option<DiagnosticSnippet<'_>> {
+    let start_byte_index = self.location.byte_index;
+    let start_char_len = &self.text_info.text()[start_byte_index..]
+      .chars()
+      .next()
+      .map(|ch| ch.len_utf8())
+      .unwrap_or(1);
     Some(DiagnosticSnippet {
       source: Cow::Borrowed(&self.text_info),
       highlights: vec![DiagnosticSnippetHighlight {
         style: DiagnosticSnippetHighlightStyle::Error,
         range: DiagnosticSourceRange {
-          start: DiagnosticSourcePos::ByteIndex(self.location.byte_index),
-          end: DiagnosticSourcePos::ByteIndex(self.location.byte_index + 1),
+          start: DiagnosticSourcePos::ByteIndex(start_byte_index),
+          end: DiagnosticSourcePos::ByteIndex(
+            start_byte_index + start_char_len,
+          ),
         },
         description: None,
       }],

--- a/tests/specs/interface_declaration_with_non_ascii_characters.txt
+++ b/tests/specs/interface_declaration_with_non_ascii_characters.txt
@@ -1,0 +1,182 @@
+# mod.ts
+// 插件描述文件 `pmimp.json`
+export interface 插件描述 {
+  pmim_version: string;
+  插件信息: {
+    名称: string;
+    描述: string;
+    版本: string;
+    URL: string;
+  };
+}
+
+# diagnostics
+error[missing-jsdoc]: exported symbol is missing JSDoc documentation
+ --> /mod.ts:2:1
+  | 
+2 | export interface 插件描述 {
+  | ^
+
+
+error[missing-jsdoc]: exported symbol is missing JSDoc documentation
+ --> /mod.ts:3:3
+  | 
+3 |   pmim_version: string;
+  |   ^
+
+
+error[missing-jsdoc]: exported symbol is missing JSDoc documentation
+ --> /mod.ts:4:3
+  | 
+4 |   插件信息: {
+  |   ^^
+
+# output.txt
+Defined in file:///mod.ts:2:1
+
+interface 插件描述
+
+  pmim_version: string
+  插件信息: { 名称: string; 描述: string; 版本: string; URL: string; }
+
+
+# output.json
+[
+  {
+    "name": "插件描述",
+    "isDefault": false,
+    "location": {
+      "filename": "file:///mod.ts",
+      "line": 2,
+      "col": 0,
+      "byteIndex": 35
+    },
+    "declarationKind": "export",
+    "kind": "interface",
+    "interfaceDef": {
+      "extends": [],
+      "constructors": [],
+      "methods": [],
+      "properties": [
+        {
+          "name": "pmim_version",
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 3,
+            "col": 2,
+            "byteIndex": 69
+          },
+          "params": [],
+          "computed": false,
+          "optional": false,
+          "tsType": {
+            "repr": "string",
+            "kind": "keyword",
+            "keyword": "string"
+          },
+          "typeParams": []
+        },
+        {
+          "name": "插件信息",
+          "location": {
+            "filename": "file:///mod.ts",
+            "line": 4,
+            "col": 2,
+            "byteIndex": 93
+          },
+          "params": [],
+          "computed": false,
+          "optional": false,
+          "tsType": {
+            "repr": "",
+            "kind": "typeLiteral",
+            "typeLiteral": {
+              "constructors": [],
+              "methods": [],
+              "properties": [
+                {
+                  "name": "名称",
+                  "location": {
+                    "filename": "file:///mod.ts",
+                    "line": 5,
+                    "col": 4,
+                    "byteIndex": 113
+                  },
+                  "params": [],
+                  "computed": false,
+                  "optional": false,
+                  "tsType": {
+                    "repr": "string",
+                    "kind": "keyword",
+                    "keyword": "string"
+                  },
+                  "typeParams": []
+                },
+                {
+                  "name": "描述",
+                  "location": {
+                    "filename": "file:///mod.ts",
+                    "line": 6,
+                    "col": 4,
+                    "byteIndex": 133
+                  },
+                  "params": [],
+                  "computed": false,
+                  "optional": false,
+                  "tsType": {
+                    "repr": "string",
+                    "kind": "keyword",
+                    "keyword": "string"
+                  },
+                  "typeParams": []
+                },
+                {
+                  "name": "版本",
+                  "location": {
+                    "filename": "file:///mod.ts",
+                    "line": 7,
+                    "col": 4,
+                    "byteIndex": 153
+                  },
+                  "params": [],
+                  "computed": false,
+                  "optional": false,
+                  "tsType": {
+                    "repr": "string",
+                    "kind": "keyword",
+                    "keyword": "string"
+                  },
+                  "typeParams": []
+                },
+                {
+                  "name": "URL",
+                  "location": {
+                    "filename": "file:///mod.ts",
+                    "line": 8,
+                    "col": 4,
+                    "byteIndex": 173
+                  },
+                  "params": [],
+                  "computed": false,
+                  "optional": false,
+                  "tsType": {
+                    "repr": "string",
+                    "kind": "keyword",
+                    "keyword": "string"
+                  },
+                  "typeParams": []
+                }
+              ],
+              "callSignatures": [],
+              "indexSignatures": []
+            }
+          },
+          "typeParams": []
+        }
+      ],
+      "callSignatures": [],
+      "indexSignatures": [],
+      "typeParams": []
+    }
+  }
+]


### PR DESCRIPTION
This commit resolves a panic in the text_info function, which occurs when attempting to slice a string containing non-ASCII characters.

The fix addresses the issue reported in the Deno repository: https://github.com/denoland/deno/issues/23875

Issue:
The problem arises when running deno doc --lint. The code attempts to extract a portion of text from the source code based on a highlight range [start, end]. However, if the text contains non-ASCII characters, such as Chinese characters, a panic occurs. This happens because the code assumes that characters occupy only one byte (as in ASCII), and it incorrectly increments the range start to a fixed value of "+1" to calculate the range end. For multi-byte non-ASCII characters, this leads to an invalid range for the end value, causing a panic during string slicing.

Solution:
The fix adjusts the logic to calculate the end of the range correctly based on the actual byte size of the character, whether it's ASCII or non-ASCII. Instead of always incrementing the range by +1 (start index + 1), the new approach adds the correct byte size of the character (start index + char size of bytes), ensuring that the range is valid for both single-byte and multi-byte characters.

![image](https://github.com/user-attachments/assets/2e3eadb2-add5-49e1-b225-658add41ae0d)
