### PR TITLE
chore: create import map for dependencies

### DIFF
--- a/build_css.ts
+++ b/build_css.ts
@@ -1,6 +1,6 @@
-import $ from "jsr:@david/dax@0.40.1";
-import browserslist from "npm:browserslist@4.23.0";
-import { browserslistToTargets, transform } from "npm:lightningcss";
+import $ from "@david/dax";
+import browserslist from "browserslist";
+import { browserslistToTargets, transform } from "lightningcss";
 
 const browsers = browserslist(">= 0.5%, not dead");
 

--- a/deno.json
+++ b/deno.json
@@ -22,5 +22,14 @@
       "src/html",
       "tests/testdata"
     ]
+  },
+  "imports": {
+    "@david/dax": "jsr:@david/dax@0.40.1",
+    "@deno/cache-dir": "jsr:@deno/cache-dir@^0.11.1",
+    "@deno/graph": "jsr:@deno/graph@^0.82.3",
+    "@std/assert": "jsr:@std/assert@^0.223.0",
+    "browserslist": "npm:browserslist@4.23.0",
+    "lightningcss": "npm:lightningcss@^1.28.2",
+    "tailwindcss": "npm:tailwindcss@3.4.3"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -4,8 +4,10 @@
     "jsr:@david/dax@0.40.1": "0.40.1",
     "jsr:@david/which@0.3": "0.3.0",
     "jsr:@deno/cache-dir@0.11": "0.11.1",
+    "jsr:@deno/cache-dir@~0.11.1": "0.11.1",
     "jsr:@deno/graph@0.82": "0.82.0",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
+    "jsr:@deno/graph@~0.82.3": "0.82.3",
     "jsr:@std/assert@0.221": "0.221.0",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/bytes@0.221": "0.221.0",
@@ -23,6 +25,7 @@
     "jsr:@std/streams@0.221.0": "0.221.0",
     "npm:browserslist@4.23.0": "4.23.0",
     "npm:lightningcss@*": "1.26.0",
+    "npm:lightningcss@^1.28.2": "1.28.2",
     "npm:tailwindcss@3.4.3": "3.4.3_postcss@8.4.41"
   },
   "jsr": {
@@ -55,6 +58,9 @@
     },
     "@deno/graph@0.82.0": {
       "integrity": "b39c8ca479116ad32c338f7a1ba99ffd21c63792b0242d6f66b2f053945e3729"
+    },
+    "@deno/graph@0.82.3": {
+      "integrity": "5c1fe944368172a9c87588ac81b82eb027ca78002a57521567e6264be322637e"
     },
     "@std/assert@0.221.0": {
       "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
@@ -407,47 +413,93 @@
     "lightningcss-darwin-arm64@1.26.0": {
       "integrity": "sha512-n4TIvHO1NY1ondKFYpL2ZX0bcC2y6yjXMD6JfyizgR8BCFNEeArINDzEaeqlfX9bXz73Bpz/Ow0nu+1qiDrBKg=="
     },
+    "lightningcss-darwin-arm64@1.28.2": {
+      "integrity": "sha512-/8cPSqZiusHSS+WQz0W4NuaqFjquys1x+NsdN/XOHb+idGHJSoJ7SoQTVl3DZuAgtPZwFZgRfb/vd1oi8uX6+g=="
+    },
     "lightningcss-darwin-x64@1.26.0": {
       "integrity": "sha512-Rf9HuHIDi1R6/zgBkJh25SiJHF+dm9axUZW/0UoYCW1/8HV0gMI0blARhH4z+REmWiU1yYT/KyNF3h7tHyRXUg=="
+    },
+    "lightningcss-darwin-x64@1.28.2": {
+      "integrity": "sha512-R7sFrXlgKjvoEG8umpVt/yutjxOL0z8KWf0bfPT3cYMOW4470xu5qSHpFdIOpRWwl3FKNMUdbKtMUjYt0h2j4g=="
     },
     "lightningcss-freebsd-x64@1.26.0": {
       "integrity": "sha512-C/io7POAxp6sZxFSVGezjajMlCKQ8KSwISLLGRq8xLQpQMokYrUoqYEwmIX8mLmF6C/CZPk0gFmRSzd8biWM0g=="
     },
+    "lightningcss-freebsd-x64@1.28.2": {
+      "integrity": "sha512-l2qrCT+x7crAY+lMIxtgvV10R8VurzHAoUZJaVFSlHrN8kRLTvEg9ObojIDIexqWJQvJcVVV3vfzsEynpiuvgA=="
+    },
     "lightningcss-linux-arm-gnueabihf@1.26.0": {
       "integrity": "sha512-Aag9kqXqkyPSW+dXMgyWk66C984Nay2pY8Nws+67gHlDzV3cWh7TvFlzuaTaVFMVqdDTzN484LSK3u39zFBnzg=="
+    },
+    "lightningcss-linux-arm-gnueabihf@1.28.2": {
+      "integrity": "sha512-DKMzpICBEKnL53X14rF7hFDu8KKALUJtcKdFUCW5YOlGSiwRSgVoRjM97wUm/E0NMPkzrTi/rxfvt7ruNK8meg=="
     },
     "lightningcss-linux-arm64-gnu@1.26.0": {
       "integrity": "sha512-iJmZM7fUyVjH+POtdiCtExG+67TtPUTer7K/5A8DIfmPfrmeGvzfRyBltGhQz13Wi15K1lf2cPYoRaRh6vcwNA=="
     },
+    "lightningcss-linux-arm64-gnu@1.28.2": {
+      "integrity": "sha512-nhfjYkfymWZSxdtTNMWyhFk2ImUm0X7NAgJWFwnsYPOfmtWQEapzG/DXZTfEfMjSzERNUNJoQjPAbdqgB+sjiw=="
+    },
     "lightningcss-linux-arm64-musl@1.26.0": {
       "integrity": "sha512-XxoEL++tTkyuvu+wq/QS8bwyTXZv2y5XYCMcWL45b8XwkiS8eEEEej9BkMGSRwxa5J4K+LDeIhLrS23CpQyfig=="
+    },
+    "lightningcss-linux-arm64-musl@1.28.2": {
+      "integrity": "sha512-1SPG1ZTNnphWvAv8RVOymlZ8BDtAg69Hbo7n4QxARvkFVCJAt0cgjAw1Fox0WEhf4PwnyoOBaVH0Z5YNgzt4dA=="
     },
     "lightningcss-linux-x64-gnu@1.26.0": {
       "integrity": "sha512-1dkTfZQAYLj8MUSkd6L/+TWTG8V6Kfrzfa0T1fSlXCXQHrt1HC1/UepXHtKHDt/9yFwyoeayivxXAsApVxn6zA=="
     },
+    "lightningcss-linux-x64-gnu@1.28.2": {
+      "integrity": "sha512-ZhQy0FcO//INWUdo/iEdbefntTdpPVQ0XJwwtdbBuMQe+uxqZoytm9M+iqR9O5noWFaxK+nbS2iR/I80Q2Ofpg=="
+    },
     "lightningcss-linux-x64-musl@1.26.0": {
       "integrity": "sha512-yX3Rk9m00JGCUzuUhFEojY+jf/6zHs3XU8S8Vk+FRbnr4St7cjyMXdNjuA2LjiT8e7j8xHRCH8hyZ4H/btRE4A=="
+    },
+    "lightningcss-linux-x64-musl@1.28.2": {
+      "integrity": "sha512-alb/j1NMrgQmSFyzTbN1/pvMPM+gdDw7YBuQ5VSgcFDypN3Ah0BzC2dTZbzwzaMdUVDszX6zH5MzjfVN1oGuww=="
     },
     "lightningcss-win32-arm64-msvc@1.26.0": {
       "integrity": "sha512-X/597/cFnCogy9VItj/+7Tgu5VLbAtDF7KZDPdSw0MaL6FL940th1y3HiOzFIlziVvAtbo0RB3NAae1Oofr+Tw=="
     },
+    "lightningcss-win32-arm64-msvc@1.28.2": {
+      "integrity": "sha512-WnwcjcBeAt0jGdjlgbT9ANf30pF0C/QMb1XnLnH272DQU8QXh+kmpi24R55wmWBwaTtNAETZ+m35ohyeMiNt+g=="
+    },
     "lightningcss-win32-x64-msvc@1.26.0": {
       "integrity": "sha512-pYS3EyGP3JRhfqEFYmfFDiZ9/pVNfy8jVIYtrx9TVNusVyDK3gpW1w/rbvroQ4bDJi7grdUtyrYU6V2xkY/bBw=="
+    },
+    "lightningcss-win32-x64-msvc@1.28.2": {
+      "integrity": "sha512-3piBifyT3avz22o6mDKywQC/OisH2yDK+caHWkiMsF82i3m5wDBadyCjlCQ5VNgzYkxrWZgiaxHDdd5uxsi0/A=="
     },
     "lightningcss@1.26.0": {
       "integrity": "sha512-a/XZ5hdgifrofQJUArr5AiJjx26SwMam3SJUSMjgebZbESZ96i+6Qsl8tLi0kaUsdMzBWXh9sN1Oe6hp2/dkQw==",
       "dependencies": [
         "detect-libc",
-        "lightningcss-darwin-arm64",
-        "lightningcss-darwin-x64",
-        "lightningcss-freebsd-x64",
-        "lightningcss-linux-arm-gnueabihf",
-        "lightningcss-linux-arm64-gnu",
-        "lightningcss-linux-arm64-musl",
-        "lightningcss-linux-x64-gnu",
-        "lightningcss-linux-x64-musl",
-        "lightningcss-win32-arm64-msvc",
-        "lightningcss-win32-x64-msvc"
+        "lightningcss-darwin-arm64@1.26.0",
+        "lightningcss-darwin-x64@1.26.0",
+        "lightningcss-freebsd-x64@1.26.0",
+        "lightningcss-linux-arm-gnueabihf@1.26.0",
+        "lightningcss-linux-arm64-gnu@1.26.0",
+        "lightningcss-linux-arm64-musl@1.26.0",
+        "lightningcss-linux-x64-gnu@1.26.0",
+        "lightningcss-linux-x64-musl@1.26.0",
+        "lightningcss-win32-arm64-msvc@1.26.0",
+        "lightningcss-win32-x64-msvc@1.26.0"
+      ]
+    },
+    "lightningcss@1.28.2": {
+      "integrity": "sha512-ePLRrbt3fgjXI5VFZOLbvkLD5ZRuxGKm+wJ3ujCqBtL3NanDHPo/5zicR5uEKAPiIjBYF99BM4K4okvMznjkVA==",
+      "dependencies": [
+        "detect-libc",
+        "lightningcss-darwin-arm64@1.28.2",
+        "lightningcss-darwin-x64@1.28.2",
+        "lightningcss-freebsd-x64@1.28.2",
+        "lightningcss-linux-arm-gnueabihf@1.28.2",
+        "lightningcss-linux-arm64-gnu@1.28.2",
+        "lightningcss-linux-arm64-musl@1.28.2",
+        "lightningcss-linux-x64-gnu@1.28.2",
+        "lightningcss-linux-x64-musl@1.28.2",
+        "lightningcss-win32-arm64-msvc@1.28.2",
+        "lightningcss-win32-x64-msvc@1.28.2"
       ]
     },
     "lilconfig@2.1.0": {
@@ -755,5 +807,16 @@
     "yaml@2.5.0": {
       "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@david/dax@0.40.1",
+      "jsr:@deno/cache-dir@~0.11.1",
+      "jsr:@deno/graph@~0.82.3",
+      "jsr:@std/assert@0.223",
+      "npm:browserslist@4.23.0",
+      "npm:lightningcss@^1.28.2",
+      "npm:tailwindcss@3.4.3"
+    ]
   }
 }

--- a/js/allow_leak_test.ts
+++ b/js/allow_leak_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { assertRejects } from "jsr:@std/assert@0.223";
+import { assertRejects } from "@std/assert";
 import { doc } from "./mod.ts";
 
 Deno.test({

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -2,10 +2,10 @@
 
 import { instantiate } from "./deno_doc_wasm.generated.js";
 import type { DocNode, Location } from "./types.d.ts";
-import { createCache } from "jsr:@deno/cache-dir@0.11";
-import type { CacheSetting, LoadResponse } from "jsr:@deno/graph@0.82";
+import { createCache } from "@deno/cache-dir";
+import type { CacheSetting, LoadResponse } from "@deno/graph";
 
-export type { CacheSetting, LoadResponse } from "jsr:@deno/graph@0.82";
+export type { CacheSetting, LoadResponse } from "@deno/graph";
 export * from "./types.d.ts";
 
 const encoder = new TextEncoder();

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,4 @@
-import { type Config } from "npm:tailwindcss@3.4.3";
+import { type Config } from "tailwindcss";
 
 const TAG_PURPLE = "#7B61FF";
 const TAG_CYAN = "#0CAFC6";


### PR DESCRIPTION
This pull request makes the TypeScript files use an import map instead of them all listing their dependencies and versions individually. Making dependency management easier, and hopefully if https://github.com/denoland/deno_cache_dir/pull/67 gets merged, another pull request to update `@deno/cache-dir` so those warnings mentioned in that pull request go away in `@std`.