### PR TITLE
refactor: remove `DocNodeKind`

### DIFF
--- a/examples/ddoc/main.rs
+++ b/examples/ddoc/main.rs
@@ -3,11 +3,12 @@
 use clap::App;
 use clap::Arg;
 use deno_doc::find_nodes_by_name_recursively;
+use deno_doc::html::GenerateCtx;
+use deno_doc::html::HrefResolver;
 use deno_doc::html::UrlResolveKind;
 use deno_doc::html::UsageComposer;
 use deno_doc::html::UsageComposerEntry;
-use deno_doc::html::{GenerateCtx, HrefResolver};
-use deno_doc::DocNodeKind;
+use deno_doc::node::DocNodeDef;
 use deno_doc::DocParser;
 use deno_doc::DocParserOptions;
 use deno_doc::DocPrinter;
@@ -151,7 +152,8 @@ async fn run() -> anyhow::Result<()> {
   let mut doc_nodes =
     parser.parse()?.into_values().flatten().collect::<Vec<_>>();
 
-  doc_nodes.retain(|doc_node| doc_node.kind() != DocNodeKind::Import);
+  doc_nodes
+    .retain(|doc_node| !matches!(doc_node.def, DocNodeDef::Import { .. }));
   if let Some(filter) = maybe_filter {
     doc_nodes = find_nodes_by_name_recursively(doc_nodes, filter);
   }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -3,13 +3,13 @@
 use crate::js_doc::JsDoc;
 use crate::node::DeclarationKind;
 use crate::node::DocNode;
+use crate::node::DocNodeDef;
 use crate::node::NamespaceDef;
 use crate::ts_type::TsTypeDef;
 use crate::util::swc::get_text_info_location;
 use crate::util::swc::has_ignorable_js_doc_tag;
 use crate::util::symbol::symbol_has_ignorable_js_doc_tag;
 use crate::variable::VariableDef;
-use crate::DocNodeKind;
 use crate::Location;
 
 use deno_ast::diagnostics::Diagnostic;
@@ -394,18 +394,18 @@ impl DiagnosticDocNodeVisitor<'_, '_> {
   }
 
   fn visit_doc_node(&mut self, doc_node: &DocNode) {
-    fn is_js_docable_kind(kind: &DocNodeKind) -> bool {
-      match kind {
-        DocNodeKind::Class
-        | DocNodeKind::Enum
-        | DocNodeKind::Function
-        | DocNodeKind::Interface
-        | DocNodeKind::Namespace
-        | DocNodeKind::TypeAlias
-        | DocNodeKind::Variable => true,
-        DocNodeKind::Import
-        | DocNodeKind::ModuleDoc
-        | DocNodeKind::Reference => false,
+    fn is_js_docable_kind(node: &DocNode) -> bool {
+      match node.def {
+        DocNodeDef::Class { .. }
+        | DocNodeDef::Enum { .. }
+        | DocNodeDef::Function { .. }
+        | DocNodeDef::Interface { .. }
+        | DocNodeDef::Namespace { .. }
+        | DocNodeDef::TypeAlias { .. }
+        | DocNodeDef::Variable { .. } => true,
+        DocNodeDef::Import { .. }
+        | DocNodeDef::ModuleDoc { .. }
+        | DocNodeDef::Reference { .. } => false,
       }
     }
 
@@ -413,7 +413,7 @@ impl DiagnosticDocNodeVisitor<'_, '_> {
       return; // skip, we don't do these diagnostics above private nodes
     }
 
-    if is_js_docable_kind(&doc_node.kind()) {
+    if is_js_docable_kind(doc_node) {
       self
         .diagnostics
         .check_missing_js_doc(&doc_node.js_doc, &doc_node.location);

--- a/src/html/jsdoc.rs
+++ b/src/html/jsdoc.rs
@@ -3,7 +3,7 @@ use super::util::*;
 use crate::html::ShortPath;
 use crate::js_doc::JsDoc;
 use crate::js_doc::JsDocTag;
-use crate::DocNodeKind;
+use crate::node::DocNodeDef;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::rc::Rc;
@@ -330,7 +330,7 @@ impl ModuleDocCtx {
 
     let (deprecated, html) = if let Some(node) = module_doc_nodes
       .iter()
-      .find(|n| n.kind() == DocNodeKind::ModuleDoc)
+      .find(|n| matches!(n.def, DocNodeDef::ModuleDoc))
     {
       let deprecated = node.js_doc.tags.iter().find_map(|tag| {
         if let JsDocTag::Deprecated { doc } = tag {

--- a/src/html/pages.rs
+++ b/src/html/pages.rs
@@ -25,7 +25,7 @@ use super::STYLESHEET_FILENAME;
 
 use crate::html::usage::UsagesCtx;
 use crate::js_doc::JsDocTag;
-use crate::DocNodeKind;
+use crate::node::DocNodeDef;
 use indexmap::IndexMap;
 use serde::Serialize;
 
@@ -260,7 +260,7 @@ impl IndexCtx {
           .map(|(short_path, nodes)| {
             let doc = nodes
               .iter()
-              .find(|node| node.kind() == DocNodeKind::ModuleDoc)
+              .find(|node| matches!(node.def, DocNodeDef::ModuleDoc))
               .and_then(|node| {
                 crate::html::jsdoc::jsdoc_body_to_html(
                   &render_ctx,
@@ -552,7 +552,7 @@ pub fn generate_symbol_pages_for_module(
 
     if doc_nodes
       .iter()
-      .any(|doc_node| doc_node.kind() == DocNodeKind::Class)
+      .any(|doc_node| matches!(doc_node.def, DocNodeDef::Class { .. }))
     {
       let prototype_name = format!("{name}.prototype");
       generated_pages.push(SymbolPage::Redirect {

--- a/src/html/search.rs
+++ b/src/html/search.rs
@@ -38,7 +38,7 @@ fn doc_nodes_into_search_index_node(
   let kinds = doc_nodes
     .iter()
     .map(|node| {
-      let kind = DocNodeKindCtx::from(node.kind_with_drilldown);
+      let kind = DocNodeKindCtx::from(node.kind);
       SlimKindCtx {
         char: kind.char,
         kind: kind.kind,

--- a/src/html/symbols/namespace.rs
+++ b/src/html/symbols/namespace.rs
@@ -1,8 +1,8 @@
 use crate::html::render_context::RenderContext;
 use crate::html::util::*;
-use crate::html::DocNodeKindWithDrilldown;
+use crate::html::DocNodeKind;
 use crate::html::DocNodeWithContext;
-use deno_ast::swc::ast::MethodKind;
+use crate::html::MethodKind;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use serde::Serialize;
@@ -137,12 +137,12 @@ impl NamespaceNodeCtx {
               !symbol.drilldown_name.as_ref().unwrap().starts_with('[')
             })
             .map(|symbol| {
-              let id = match symbol.kind_with_drilldown {
-                DocNodeKindWithDrilldown::Property => name_to_id(
+              let id = match symbol.kind {
+                DocNodeKind::Property => name_to_id(
                   "property",
                   &symbol.drilldown_name.as_ref().unwrap().to_lowercase(),
                 ),
-                DocNodeKindWithDrilldown::Method(kind) => {
+                DocNodeKind::Method(kind) => {
                   if matches!(kind, MethodKind::Getter | MethodKind::Setter) {
                     name_to_id(
                       "accessor",
@@ -158,7 +158,7 @@ impl NamespaceNodeCtx {
                     )
                   }
                 }
-                DocNodeKindWithDrilldown::Other(_) => unreachable!(),
+                _ => unreachable!(),
               };
 
               NamespaceNodeSubItemCtx {
@@ -176,10 +176,7 @@ impl NamespaceNodeCtx {
       id: id.clone(),
       anchor: AnchorCtx { id },
       tags,
-      doc_node_kind_ctx: nodes
-        .iter()
-        .map(|node| node.kind_with_drilldown.into())
-        .collect(),
+      doc_node_kind_ctx: nodes.iter().map(|node| node.kind.into()).collect(),
       href,
       name,
       docs,

--- a/src/html/usage.rs
+++ b/src/html/usage.rs
@@ -3,7 +3,7 @@ use super::FileMode;
 use super::RenderContext;
 use super::UrlResolveKind;
 use crate::js_doc::JsDocTag;
-use crate::DocNodeKind;
+use crate::node::DocNodeDef;
 use indexmap::IndexMap;
 use regex::Regex;
 use serde::Serialize;
@@ -108,8 +108,9 @@ fn usage_to_md(
           doc_node
             .parent
             .as_ref()
-            .map_or_else(|| doc_node.kind(), |parent| parent.kind()),
-          DocNodeKind::TypeAlias | DocNodeKind::Interface
+            .map_or_else(|| &doc_node.inner, |parent| &parent.inner)
+            .def,
+          DocNodeDef::TypeAlias { .. } | DocNodeDef::Interface { .. }
         )
       });
 
@@ -159,7 +160,7 @@ fn get_identifier_for_file(
         .and_then(|nodes| {
           nodes
             .iter()
-            .find(|node| node.kind() == DocNodeKind::ModuleDoc)
+            .find(|node| matches!(node.def, DocNodeDef::ModuleDoc))
         })
         .and_then(|node| {
           node.js_doc.tags.iter().find_map(|tag| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod variable;
 mod visibility;
 
 pub use node::DocNode;
-pub use node::DocNodeKind;
+pub use node::DocNodeDef;
 pub use node::Location;
 
 use node::ImportDef;
@@ -103,7 +103,7 @@ fn get_children_of_node(node: DocNode) -> Vec<DocNode> {
     DocNodeDef::Namespace { namespace_def } => namespace_def
       .elements
       .into_iter()
-      .map(std::rc::Rc::unwrap_or_clone)
+      .map(std::sync::Arc::unwrap_or_clone)
       .collect(),
     DocNodeDef::Interface { interface_def } => {
       let mut doc_nodes: Vec<DocNode> = vec![];

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,14 +1,13 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use crate::js_doc::JsDoc;
 use serde::Deserialize;
 use serde::Serialize;
-use std::rc::Rc;
-
-use crate::js_doc::JsDoc;
+use std::sync::Arc;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct NamespaceDef {
-  pub elements: Vec<Rc<DocNode>>,
+  pub elements: Vec<Arc<DocNode>>,
 }
 
 #[derive(
@@ -353,21 +352,6 @@ impl DocNode {
     };
 
     default_name.unwrap_or(&self.name)
-  }
-
-  pub fn kind(&self) -> DocNodeKind {
-    match &self.def {
-      DocNodeDef::Class { .. } => DocNodeKind::Class,
-      DocNodeDef::Function { .. } => DocNodeKind::Function,
-      DocNodeDef::Variable { .. } => DocNodeKind::Variable,
-      DocNodeDef::Enum { .. } => DocNodeKind::Enum,
-      DocNodeDef::TypeAlias { .. } => DocNodeKind::TypeAlias,
-      DocNodeDef::Namespace { .. } => DocNodeKind::Namespace,
-      DocNodeDef::Interface { .. } => DocNodeKind::Interface,
-      DocNodeDef::Import { .. } => DocNodeKind::Import,
-      DocNodeDef::ModuleDoc => DocNodeKind::ModuleDoc,
-      DocNodeDef::Reference { .. } => DocNodeKind::Reference,
-    }
   }
 
   pub fn class_def(&self) -> Option<&super::class::ClassDef> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use crate::node::DocNodeDef;
 use crate::parser::DocParser;
 use crate::printer::DocPrinter;
 use crate::DocParserOptions;
@@ -580,7 +581,6 @@ export * as b from "./mod_doc.ts";
 #[tokio::test]
 async fn filter_nodes_by_name() {
   use crate::find_nodes_by_name_recursively;
-  use crate::DocNodeKind;
   let source_code = r#"
 export namespace Deno {
   export class Buffer {}
@@ -645,28 +645,28 @@ export namespace Deno {
   let found = find_nodes_by_name_recursively(entries.clone(), "Deno.Conn.rid");
   assert_eq!(found.len(), 1);
   assert_eq!(found[0].name.as_ref(), "rid");
-  assert_eq!(found[0].kind(), DocNodeKind::Variable);
+  assert!(matches!(found[0].def, DocNodeDef::Variable { .. }));
 
   // Interface method
   let found =
     find_nodes_by_name_recursively(entries.clone(), "Deno.Conn.closeWrite");
   assert_eq!(found.len(), 1);
   assert_eq!(found[0].name.as_ref(), "closeWrite");
-  assert_eq!(found[0].kind(), DocNodeKind::Function);
+  assert!(matches!(found[0].def, DocNodeDef::Function { .. }));
 
   // Class property
   let found =
     find_nodes_by_name_recursively(entries.clone(), "Deno.Process.pid");
   assert_eq!(found.len(), 1);
   assert_eq!(found[0].name.as_ref(), "pid");
-  assert_eq!(found[0].kind(), DocNodeKind::Variable);
+  assert!(matches!(found[0].def, DocNodeDef::Variable { .. }));
 
   // Class method
   let found =
     find_nodes_by_name_recursively(entries.clone(), "Deno.Process.output");
   assert_eq!(found.len(), 1);
   assert_eq!(found[0].name.as_ref(), "output");
-  assert_eq!(found[0].kind(), DocNodeKind::Function);
+  assert!(matches!(found[0].def, DocNodeDef::Function { .. }));
 
   // No match
   let found = find_nodes_by_name_recursively(entries.clone(), "Deno.test.a");


### PR DESCRIPTION
This doesnt affect JSON output, only the rust API.
This is done in favour of just operating of `DocNodeDef` variants instead of having a special type that mirrors all the variants

Also changes `NamespaceDef` elements to be stored as `Arc` instead of `Rc`.

the html gen still has a `DocNodeKindWithDrilldown` (renamed to `DocNodeKind` in this PR for simplicity), which is mainly used for ordering, which should be moved to ordering on `DocNodeDef` and then also add ordering on `DocNode` since we need that in a few spots.
Additionally its also used for grouping of nodes, but that could be cleaned up to use `DocNodeKindCtx` instead.
However not doing that in this PR.