### PR TITLE
chore: deno_ast 0.46.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.89.0"
+version = "0.89.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca8039ee1325d0d5dd60765c55177dc16b904f2457185ca815829d1e83eb588"
+checksum = "5d12e08a843ed1dbef68de3720092e67dcb958eae59ec2f26a459597c2c76be0"
 dependencies = [
  "async-trait",
  "capacity_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/denoland/deno_doc"
 members = ["lib"]
 
 [workspace.dependencies]
-deno_graph = { version = "0.89.0", default-features = false, features = ["symbols"] }
+deno_graph = { version = "0.89.4", default-features = false, features = ["symbols"] }
 deno_ast = { version = "0.46.3" }
 import_map = "0.21.0"
 serde = { version = "1.0.204", features = ["derive"] }


### PR DESCRIPTION
This is to ensure the tests still pass.