### PR TITLE
fix panic

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -341,7 +341,13 @@ impl<'a> DocParser<'a> {
                     definitions.first().unwrap().module.specifier(),
                     reference_def,
                     // -1 to include the root
-                    name_path[(if i > 1 { i - 1 } else { 0 })..].to_vec(),
+                    if i > 1 {
+                      name_path[i - 1..].to_vec()
+                    } else {
+                      let mut out = vec![root_name];
+                      out.extend_from_slice(&name_path);
+                      out
+                    },
                     false,
                   );
                 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -341,7 +341,7 @@ impl<'a> DocParser<'a> {
                     definitions.first().unwrap().module.specifier(),
                     reference_def,
                     // -1 to include the root
-                    name_path[i - 1..].to_vec(),
+                    name_path[(if i > 1 { i - 1 } else { 0 })..].to_vec(),
                     false,
                   );
                 };

--- a/tests/specs/namespace_reexport_member.txt
+++ b/tests/specs/namespace_reexport_member.txt
@@ -182,34 +182,7 @@ Defined in file:///mod.ts:1:1
           },
           "kind": "namespace",
           "namespaceDef": {
-            "elements": [
-              {
-                "name": "Completions",
-                "isDefault": false,
-                "location": {
-                  "filename": "file:///chat_completions.ts",
-                  "line": 2,
-                  "col": 0,
-                  "byteIndex": 11
-                },
-                "declarationKind": "export",
-                "jsDoc": {
-                  "doc": "Doc"
-                },
-                "kind": "class",
-                "classDef": {
-                  "isAbstract": false,
-                  "constructors": [],
-                  "properties": [],
-                  "indexSignatures": [],
-                  "methods": [],
-                  "extends": null,
-                  "implements": [],
-                  "typeParams": [],
-                  "superTypeParams": []
-                }
-              }
-            ]
+            "elements": []
           }
         }
       ]

--- a/tests/specs/panic_subtract_with_overflow.txt
+++ b/tests/specs/panic_subtract_with_overflow.txt
@@ -1,0 +1,43 @@
+# mod.ts
+export { Audio } from './audio.ts';
+
+# audio.ts
+import { Speech } from './speech.ts';
+
+/** Some documentation. **/
+export namespace Audio {
+  export { Speech as Speech };
+}
+
+# speech.ts
+export namespace Speech {}
+
+# output.txt
+Defined in file:///audio.ts:4:1
+
+namespace Audio
+  Some documentation. *
+
+
+
+# output.json
+[
+  {
+    "name": "Audio",
+    "isDefault": false,
+    "location": {
+      "filename": "file:///audio.ts",
+      "line": 4,
+      "col": 0,
+      "byteIndex": 67
+    },
+    "declarationKind": "export",
+    "jsDoc": {
+      "doc": "Some documentation. *"
+    },
+    "kind": "namespace",
+    "namespaceDef": {
+      "elements": []
+    }
+  }
+]

--- a/tests/specs/panic_subtract_with_overflow.txt
+++ b/tests/specs/panic_subtract_with_overflow.txt
@@ -4,20 +4,23 @@ export { Audio } from './audio.ts';
 # audio.ts
 import { Speech } from './speech.ts';
 
-/** Some documentation. **/
+/** Some documentation. */
 export namespace Audio {
   export { Speech as Speech };
 }
 
 # speech.ts
+/** Some documentation. */
 export namespace Speech {}
 
 # output.txt
 Defined in file:///audio.ts:4:1
 
 namespace Audio
-  Some documentation. *
+  Some documentation.
 
+  namespace Speech
+    Some documentation.
 
 
 # output.json
@@ -29,15 +32,34 @@ namespace Audio
       "filename": "file:///audio.ts",
       "line": 4,
       "col": 0,
-      "byteIndex": 67
+      "byteIndex": 66
     },
     "declarationKind": "export",
     "jsDoc": {
-      "doc": "Some documentation. *"
+      "doc": "Some documentation."
     },
     "kind": "namespace",
     "namespaceDef": {
-      "elements": []
+      "elements": [
+        {
+          "name": "Speech",
+          "isDefault": false,
+          "location": {
+            "filename": "file:///speech.ts",
+            "line": 2,
+            "col": 0,
+            "byteIndex": 27
+          },
+          "declarationKind": "export",
+          "jsDoc": {
+            "doc": "Some documentation."
+          },
+          "kind": "namespace",
+          "namespaceDef": {
+            "elements": []
+          }
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
fixes a panic when publishing @openai/openai to jsr
```
thread 'tokio-runtime-worker' panicked at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_doc-0.171.1/src/parser.rs:345:31:
attempt to subtract with overflow
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:74:14
   2: core::panicking::panic_const::panic_const_sub_overflow
             at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:181:21
   3: deno_doc::parser::DocParser::resolve_dangling_reference
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_doc-0.171.1/src/parser.rs:345:31
   4: deno_doc::parser::DocParser::resolve_references_for_nodes
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_doc-0.171.1/src/parser.rs:257:38
   5: deno_doc::parser::DocParser::resolve_references_for_nodes
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_doc-0.171.1/src/parser.rs:241:11
   6: deno_doc::parser::DocParser::parse
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_doc-0.171.1/src/parser.rs:203:7
   7: registry_api::docs::generate_docs::{{closure}}
             at ./src/docs.rs:285:26
   8: registry_api::docs::generate_docs
             at ./src/docs.rs:267:1
   9: registry_api::analysis::analyze_package_inner::{{closure}}::{{closure}}::{{closure}}
             at ./src/analysis.rs:213:5
  10: registry_api::analysis::analyze_package_inner::{{closure}}::{{closure}}
             at ./src/analysis.rs:95:1
  11: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-0.1.40/src/instrument.rs:321:9
  12: registry_api::analysis::analyze_package_inner::{{closure}}
             at ./src/analysis.rs:95:1
  13: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-0.1.40/src/instrument.rs:321:9
  14: registry_api::analysis::analyze_package::{{closure}}
             at ./src/analysis.rs:92:6
  15: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:123:9
  16: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:123:9
  17: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:696:57
  18: tokio::runtime::coop::with_budget
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:107:5
  19: tokio::runtime::coop::budget
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:73:5
  20: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:696:25
  21: tokio::runtime::scheduler::current_thread::Context::enter
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:423:19
  22: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:695:36
  23: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:774:68
  24: tokio::runtime::context::scoped::Scoped<T>::set
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/scoped.rs:40:9
  25: tokio::runtime::context::set_scheduler::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context.rs:180:26
  26: std::thread::local::LocalKey<T>::try_with
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:283:12
  27: std::thread::local::LocalKey<T>::with
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:260:9
  28: tokio::runtime::context::set_scheduler
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context.rs:180:9
  29: tokio::runtime::scheduler::current_thread::CoreGuard::enter
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:774:27
  30: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:683:19
  31: tokio::runtime::scheduler::current_thread::CurrentThread::block_on::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:191:28
  32: tokio::runtime::context::runtime::enter_runtime
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/runtime.rs:65:16
  33: tokio::runtime::scheduler::current_thread::CurrentThread::block_on
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/current_thread/mod.rs:179:9
  34: tokio::runtime::runtime::Runtime::block_on_inner
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/runtime.rs:361:47
  35: tokio::runtime::runtime::Runtime::block_on
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/runtime.rs:333:13
  36: registry_api::analysis::analyze_package
             at ./src/analysis.rs:90:3
  37: registry_api::tarball::process_tarball::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at ./src/tarball.rs:292:5
  38: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/task.rs:42:21
  39: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:331:17
  40: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/loom/std/unsafe_cell.rs:16:9
  41: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/core.rs:320:13
  42: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:500:19
  43: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:272:9
  44: std::panicking::try::do_call
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:557:40
  45: ___rust_try
  46: std::panicking::try
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:520:19
  47: std::panic::catch_unwind
             at /Users/em/.rustup/toolchains/1.83.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:358:14
  48: tokio::runtime::task::harness::poll_future
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:488:18
  49: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:209:27
  50: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/harness.rs:154:15
  51: tokio::runtime::task::raw::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:271:5
  52: tokio::runtime::task::raw::RawTask::poll
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/raw.rs:201:18
  53: tokio::runtime::task::UnownedTask<S>::run
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/task/mod.rs:473:9
  54: tokio::runtime::blocking::pool::Task::run
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/pool.rs:160:9
  55: tokio::runtime::blocking::pool::Inner::run
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/pool.rs:518:17
  56: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/em/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/blocking/pool.rs:476:13
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```