### PR TITLE
feat: jsdoc priority tag

### DIFF
--- a/src/html/partition.rs
+++ b/src/html/partition.rs
@@ -244,6 +244,34 @@ fn compare_node(
   (!node2_is_deprecated)
     .cmp(&!node1_is_deprecated)
     .then_with(|| {
+      let p1 = node1.js_doc.tags.iter().find_map(|tag| {
+        if let JsDocTag::Priority { priority } = tag {
+          Some(priority)
+        } else {
+          None
+        }
+      });
+      let p2 = node2.js_doc.tags.iter().find_map(|tag| {
+        if let JsDocTag::Priority { priority } = tag {
+          Some(priority)
+        } else {
+          None
+        }
+      });
+
+      match (p1, p2) {
+        (Some(p1), Some(p2)) => p1.cmp(p2),
+        (Some(p1), None) if p1 == &0 => Ordering::Equal,
+        (Some(p1), None) if p1.is_negative() => Ordering::Less,
+        (Some(_), None) => Ordering::Greater,
+        (None, Some(p2)) if p2 == &0 => Ordering::Equal,
+        (None, Some(p2)) if p2.is_negative() => Ordering::Greater,
+        (None, Some(_)) => Ordering::Less,
+        (None, None) => Ordering::Equal,
+      }
+      .reverse()
+    })
+    .then_with(|| {
       node1
         .get_qualified_name()
         .to_ascii_lowercase()

--- a/src/js_doc.rs
+++ b/src/js_doc.rs
@@ -11,7 +11,7 @@ lazy_static! {
   /// @tag maybe_value
   static ref JS_DOC_TAG_WITH_MAYBE_VALUE_RE: Regex = Regex::new(r"(?s)^\s*@(deprecated|module)(?:\s+(.+))?").unwrap();
   /// @tag value
-  static ref JS_DOC_TAG_WITH_VALUE_RE: Regex = Regex::new(r"(?s)^\s*@(category|group|see|example|tags|since)(?:\s+(.+))").unwrap();
+  static ref JS_DOC_TAG_WITH_VALUE_RE: Regex = Regex::new(r"(?s)^\s*@(category|group|see|example|tags|since|priority)(?:\s+(.+))").unwrap();
   /// @tag name maybe_value
   static ref JS_DOC_TAG_NAMED_WITH_MAYBE_VALUE_RE: Regex = Regex::new(r"(?s)^\s*@(callback|template|typeparam|typeParam)\s+([a-zA-Z_$]\S*)(?:\s+(.+))?").unwrap();
   /// @tag {type} name maybe_value
@@ -274,6 +274,10 @@ pub enum JsDocTag {
   Since {
     doc: Box<str>,
   },
+  /// `@priority 1`
+  Priority {
+    priority: i32,
+  },
   Unsupported {
     value: Box<str>,
   },
@@ -359,6 +363,14 @@ impl From<String> for JsDocTag {
         },
         "see" => Self::See { doc },
         "since" => Self::Since { doc },
+        "priority" => {
+          let Ok(priority) = doc.parse() else {
+            return Self::Unsupported {
+              value: value.into(),
+            };
+          };
+          Self::Priority { priority }
+        }
         _ => unreachable!("kind unexpected: {}", kind),
       }
     } else if let Some(caps) = JS_DOC_TAG_PARAM_RE.captures(&value) {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -412,6 +412,15 @@ impl DocPrinter<'_> {
         writeln!(w, "{}@{}", Indent(indent), colors::magenta("since"))?;
         self.format_jsdoc_tag_doc(w, doc, indent)
       }
+      JsDocTag::Priority { priority } => {
+        writeln!(
+          w,
+          "{}@{} {{{}}}",
+          Indent(indent),
+          colors::magenta("priority"),
+          italic_cyan(priority),
+        )
+      }
       JsDocTag::Throws { type_ref, doc } => {
         write!(w, "{}@{}", Indent(indent), colors::magenta("return"))?;
         if let Some(type_ref) = type_ref {

--- a/tests/snapshots/html_test__html_doc_files_multiple.snap
+++ b/tests/snapshots/html_test__html_doc_files_multiple.snap
@@ -121,7 +121,18 @@ expression: files.get(file_name).unwrap()
   </defs>
 </svg>
 </a>
-<a href=".&#x2F;" class="contextLink">default</a></h2></div><div class="namespaceSection"><div id="namespace_abstractclass" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Class bg-Class/15 dark:text-ClassDark dark:bg-ClassDark/15" title="Class">c</div></div>
+<a href=".&#x2F;" class="contextLink">default</a></h2></div><div class="namespaceSection"><div id="namespace_foobar" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Class bg-Class/15 dark:text-ClassDark dark:bg-ClassDark/15" title="Class">c</div></div>
+<div class="namespaceItemContent">
+		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foobar.html" title="Foobar">Foobar</a>
+
+	      <div class="namespaceItemContentDoc"><div class="markdown_summary"><p>Foobar docs</p>
+</div></div></div>
+    </div><div id="namespace_hello" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Interface bg-Interface/15 dark:text-InterfaceDark dark:bg-InterfaceDark/15" title="Interface">I</div></div>
+<div class="namespaceItemContent">
+		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html" title="Hello">Hello</a>
+
+	      <div class="namespaceItemContentDoc"><span class="italic">No documentation available</span></div><ul class="namespaceItemContentSubItems"><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_ab">ab</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#method_computedmethod_0">computedMethod</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#method_optionalmethod_0">optionalMethod</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_test">test</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_world">world</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_x">x</a></li></ul></div>
+    </div><div id="namespace_abstractclass" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Class bg-Class/15 dark:text-ClassDark dark:bg-ClassDark/15" title="Class">c</div></div>
 <div class="namespaceItemContent">
 		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;AbstractClass.html" title="AbstractClass">AbstractClass</a>
 
@@ -178,22 +189,11 @@ expression: files.get(file_name).unwrap()
 
 	      <div class="namespaceItemContentDoc"><div class="markdown_summary"><p>some Foo docs <a href="./././~/Bar.html"><code>Bar</code></a></p>
 </div></div><ul class="namespaceItemContentSubItems"><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#property_&amp;quot;&amp;gt;&amp;lt;img src=x onerror=alert(1)&amp;gt;">&quot;&gt;&lt;img src=x onerror=alert(1)&gt;</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#property_bar">bar</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#property_foo">foo</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#accessor_getter">getter</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#accessor_getterandsetter">getterAndSetter</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#method_methodwithoverloads_0">methodWithOverloads</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#property_protectedproperty">protectedProperty</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#property_readonlyproperty">readonlyProperty</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#accessor_setter">setter</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#method_staticmethod_0">staticMethod</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#accessor_staticsetter">staticSetter</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foo.html#method_test_0">test</a></li></ul></div>
-    </div><div id="namespace_foobar" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Class bg-Class/15 dark:text-ClassDark dark:bg-ClassDark/15" title="Class">c</div></div>
-<div class="namespaceItemContent">
-		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Foobar.html" title="Foobar">Foobar</a>
-
-	      <div class="namespaceItemContentDoc"><div class="markdown_summary"><p>Foobar docs</p>
-</div></div></div>
     </div><div id="namespace_functionwithoptionalparameters" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Function bg-Function/15 dark:text-FunctionDark dark:bg-FunctionDark/15" title="Function">f</div></div>
 <div class="namespaceItemContent">
 		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;functionWithOptionalParameters.html" title="functionWithOptionalParameters">functionWithOptionalParameters</a>
 
 	      <div class="namespaceItemContentDoc"><span class="italic">No documentation available</span></div></div>
-    </div><div id="namespace_hello" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Interface bg-Interface/15 dark:text-InterfaceDark dark:bg-InterfaceDark/15" title="Interface">I</div></div>
-<div class="namespaceItemContent">
-		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html" title="Hello">Hello</a>
-
-	      <div class="namespaceItemContentDoc"><span class="italic">No documentation available</span></div><ul class="namespaceItemContentSubItems"><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_ab">ab</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#method_computedmethod_0">computedMethod</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#method_optionalmethod_0">optionalMethod</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_test">test</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_world">world</a></li><li><a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;Hello.html#property_x">x</a></li></ul></div>
     </div><div id="namespace_interfacewithindexsignature" class="namespaceItem" ><div class="docNodeKindIcon"><div class="text-Interface bg-Interface/15 dark:text-InterfaceDark dark:bg-InterfaceDark/15" title="Interface">I</div></div>
 <div class="namespaceItemContent">
 		    <a href=".&#x2F;.&#x2F;.&#x2F;~&#x2F;InterfaceWithIndexSignature.html" title="InterfaceWithIndexSignature">InterfaceWithIndexSignature</a>

--- a/tests/testdata/multiple/a.ts
+++ b/tests/testdata/multiple/a.ts
@@ -98,6 +98,7 @@ export class Bar extends Foo<string> {
  * ## sub heading
  *
  * @see https://example.com
+ * @priority 10
  */
 export default class Foobar {
 }
@@ -108,6 +109,9 @@ export abstract class AbstractClass {
   abstract get getter(): string;
 }
 
+/**
+ * @priority 5
+ */
 export interface Hello<T extends string, E extends T, R = number> {
   (a: string): string;
   /**


### PR DESCRIPTION
This PR adds a new jsdoc tag: `@priority`.
It takes a number value, and acts like `z-index` in css does: a bigger number means it has higher priority, 0 same as unset and negative lower priority.

The priority affects in what order symbols are displayed in symbol lists in the HTML renderer, with greater priority showing up first.
This is especially useful for JSR, where there may be some exports you want to prioritize (or "feature").