### PR TITLE
docs: fix README example for @deno/doc

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -17,9 +17,10 @@ import { doc } from "@deno/doc";
 
 ## `doc()`
 
-The `doc()` function takes a string URL module specifier and potentially some
-options, and asynchronously resolves with an array of documentation nodes, which
-represent the surface API of the module.
+The `doc()` function takes an array of string URL module specifiers and
+potentially some options, and asynchronously resolves with a record of
+documentation nodes keyed by the module URL, which represent the surface API of
+the module.
 
 A minimal example of using `doc()` and printing out some information about a
 function:
@@ -27,7 +28,8 @@ function:
 ```ts
 import { doc } from "@deno/doc";
 
-const colorsDoc = await doc("https://deno.land/std/fmt/colors.ts");
+const records = await doc(["https://deno.land/std/fmt/colors.ts"]);
+const colorsDoc = records["https://deno.land/std/fmt/colors.ts"];
 
 for (const node of colorsDoc) {
   console.log(`name: ${node.name} kind: ${node.kind}`);

--- a/js/mod.ts
+++ b/js/mod.ts
@@ -64,24 +64,25 @@ export interface DocOptions {
 }
 
 /**
- * Generate asynchronously an array of documentation nodes for the supplied
- * module.
+ * Generate asynchronously a record of documentation nodes for the supplied
+ * modules.
  *
  * ### Example
  *
  * ```ts
- * import { doc } from "https://deno.land/x/deno_doc/mod.ts";
+ * import { doc } from "@deno/doc";
  *
- * const entries = await doc(["https://deno.land/std/fmt/colors.ts"]);
+ * const records = await doc(["https://deno.land/std/fmt/colors.ts"]);
+ * const colorsDoc = records["https://deno.land/std/fmt/colors.ts"];
  *
- * for (const entry of entries) {
- *   console.log(`name: ${entry.name} kind: ${entry.kind}`);
+ * for (const node of colorsDoc) {
+ *   console.log(`name: ${node.name} kind: ${node.kind}`);
  * }
  * ```
  *
  * @param specifiers List of the URL strings of the specifiers to document
  * @param options A set of options for generating the documentation
- * @returns A promise that resolves with an array of documentation nodes
+ * @returns A promise that resolves with a record of documentation nodes
  */
 export async function doc(
   specifiers: string[],

--- a/js/test.ts
+++ b/js/test.ts
@@ -9,7 +9,7 @@ Deno.test({
     const records = await doc(
       ["https://deno.land/std@0.104.0/fmt/colors.ts"],
     );
-    const entries = Object.values(records)[0];
+    const entries = records["https://deno.land/std@0.104.0/fmt/colors.ts"];
     assertEquals(entries.length, 49);
     const fnStripColor = entries.find((n) =>
       n.kind === "function" && n.name === "stripColor"


### PR DESCRIPTION
Fix the example code in the README and JSDoc to match the latest TypeScript definition.