### PR TITLE
fix: prevent stack overflow from cyclic reference resolution

### DIFF
--- a/src/html/partition.rs
+++ b/src/html/partition.rs
@@ -1,12 +1,14 @@
 use super::DocNodeWithContext;
 use super::GenerateCtx;
 use crate::DeclarationDef;
+use crate::Location;
 use crate::js_doc::JsDocTag;
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 pub type Partitions<T> = IndexMap<T, Vec<DocNodeWithContext>>;
 
@@ -26,6 +28,7 @@ where
     doc_nodes: Box<dyn Iterator<Item = Cow<'a, DocNodeWithContext>> + 'a>,
     flatten_namespaces: bool,
     process: &F,
+    visited_refs: &mut HashSet<Location>,
   ) where
     F: Fn(&mut IndexMap<T, Vec<DocNodeWithContext>>, &DocNodeWithContext),
   {
@@ -48,18 +51,23 @@ where
             ),
             true,
             process,
+            visited_refs,
           );
         }
 
         if let Some(reference) = decl.reference_def() {
-          partitioner_inner(
-            ctx,
-            partitions,
-            parent_node,
-            Box::new(ctx.resolve_reference(parent_node, &reference.target)),
-            flatten_namespaces,
-            process,
-          );
+          if visited_refs.insert(reference.target.clone()) {
+            partitioner_inner(
+              ctx,
+              partitions,
+              parent_node,
+              Box::new(ctx.resolve_reference(parent_node, &reference.target)),
+              flatten_namespaces,
+              process,
+              visited_refs,
+            );
+            visited_refs.remove(&reference.target);
+          }
           // hack until reference nodes are separate from normal symbols
           continue 'outer;
         }
@@ -78,6 +86,7 @@ where
     Box::new(doc_nodes),
     flatten_namespaces,
     process,
+    &mut HashSet::new(),
   );
 
   partitions
@@ -214,6 +223,7 @@ pub fn flatten_namespace<'a>(
     out: &mut Vec<Cow<'a, DocNodeWithContext>>,
     parent_node: Option<&DocNodeWithContext>,
     doc_nodes: Box<dyn Iterator<Item = Cow<'a, DocNodeWithContext>> + 'a>,
+    visited_refs: &mut HashSet<Location>,
   ) {
     let nodes: Vec<_> = doc_nodes.collect();
 
@@ -232,20 +242,25 @@ pub fn flatten_namespace<'a>(
             out,
             Some(&**node),
             Box::new(children.into_iter().map(Cow::Owned)),
+            visited_refs,
           );
         }
 
         if let Some(reference) = decl.reference_def() {
-          let resolved: Vec<_> = ctx
-            .resolve_reference(parent_node, &reference.target)
-            .map(|c| c.into_owned())
-            .collect();
-          partitioner_inner(
-            ctx,
-            out,
-            parent_node,
-            Box::new(resolved.into_iter().map(Cow::Owned)),
-          );
+          if visited_refs.insert(reference.target.clone()) {
+            let resolved: Vec<_> = ctx
+              .resolve_reference(parent_node, &reference.target)
+              .map(|c| c.into_owned())
+              .collect();
+            partitioner_inner(
+              ctx,
+              out,
+              parent_node,
+              Box::new(resolved.into_iter().map(Cow::Owned)),
+              visited_refs,
+            );
+            visited_refs.remove(&reference.target);
+          }
           // hack until reference nodes are separate from normal symbols
           continue 'outer;
         }
@@ -257,7 +272,13 @@ pub fn flatten_namespace<'a>(
 
   let mut out = vec![];
 
-  partitioner_inner(ctx, &mut out, None, Box::new(doc_nodes));
+  partitioner_inner(
+    ctx,
+    &mut out,
+    None,
+    Box::new(doc_nodes),
+    &mut HashSet::new(),
+  );
 
   out
 }


### PR DESCRIPTION
## Summary
- `partitioner_inner` in `src/html/partition.rs` (used by `create_partitioner` and `flatten_namespace`) follows `reference_def()` targets recursively with no cycle detection. Cyclic re-exports (e.g. `A` references `B` which references `A`) recurse forever and overflow the stack — reproduced as a `tokio-runtime-worker has overflowed its stack` abort inside `generate_search_index`.
- Threaded a `HashSet<Location>` through both recursive functions; a reference target already in progress is skipped, and is removed on unwind so sibling branches can still resolve it.

## Test plan
- [x] `cargo build`
- [x] `cargo test` — 155 tests pass