### PR TITLE
chore: upgrade deno_graph to 0.109

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.108.0"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ece7ecde2db52b86b1a1ebbe368bedded631e449dd0293a2c317bb25f7641c"
+checksum = "18b1634ebdfde4f040b2c40f2510969e755e5b782319a01dc9cab88ef25b7e3f"
 dependencies = [
  "async-trait",
  "boxed_error",
@@ -782,7 +782,7 @@ dependencies = [
  "futures",
  "indexmap 2.11.0",
  "log",
- "monch 0.6.0",
+ "monch",
  "once_cell",
  "parking_lot",
  "regex",
@@ -822,15 +822,15 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2625b7107cc3f61a462886d5fa77c23e063c1fd15b90e3d5ee2646e9f6178d55"
+checksum = "ff487e9bf55c39bfbc47418a009a0de0988c4fea5e48e8ca787fa7dbff8056cc"
 dependencies = [
  "capacity_builder",
  "deno_error",
  "ecow",
  "hipstr",
- "monch 0.5.0",
+ "monch",
  "once_cell",
  "serde",
  "thiserror",
@@ -1571,12 +1571,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "monch"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
 
 [[package]]
 name = "monch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/denoland/deno_doc"
 members = ["lib"]
 
 [workspace.dependencies]
-deno_graph = { version = "0.108.0", default-features = false, features = [
+deno_graph = { version = "0.109.0", default-features = false, features = [
   "swc",
   "symbols",
 ] }


### PR DESCRIPTION
Upgrades deno_graph to 0.109.0, which adds the `unstable_css_imports`
build option (denoland/deno_graph#655). Needed so the Deno CLI can upgrade
deno_graph and deno_doc in lockstep for the CSS module imports prototype
(denoland/deno#35093). No code changes required; all tests pass.