### PR TITLE
ci: do not persist checkout credentials in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - uses: denoland/setup-deno@v2
       - uses: dsherret/rust-toolchain-file@v1


### PR DESCRIPTION
The release workflow failed to push the version bump commit with a 403
denied to github-actions[bot], even though it sets the remote URL to use
DENOBOT_PAT. The cause is that actions/checkout defaults to
persist-credentials: true, which stores the default workflow token as an
http.extraheader in .git/config. That header takes precedence over
credentials embedded in the remote URL, so the push authenticated with
the read-only default token (contents: read) instead of the PAT.

Disabling credential persistence lets the PAT in the remote URL take
effect. Failed run:
https://github.com/denoland/deno_doc/actions/runs/27276557517