### PR TITLE
chore: update deno_graph to 0.110.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "deno_graph"
-version = "0.109.0"
+version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b1634ebdfde4f040b2c40f2510969e755e5b782319a01dc9cab88ef25b7e3f"
+checksum = "99fae1db677b397e79ca77b43c55da31cb994aab07ea59bd0e9e5c4e3efb97be"
 dependencies = [
  "async-trait",
  "boxed_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/denoland/deno_doc"
 members = ["lib"]
 
 [workspace.dependencies]
-deno_graph = { version = "0.109.0", default-features = false, features = [
+deno_graph = { version = "0.110.0", default-features = false, features = [
   "swc",
   "symbols",
 ] }


### PR DESCRIPTION
Updates the `deno_graph` dependency to 0.110.0. deno_graph 0.110.0 is a
breaking (0.x minor) release that adds the unstable config-imports support
(the `resolve_attribute_type_import` resolver hook and the
`unstable_config_imports` build option, denoland/deno_graph#656).

deno_doc itself needs no code changes for this: the new `BuildOptions` field
is covered by the existing `..Default::default()` construction sites, and the
new `Resolver` trait method has a default implementation. The bump is needed
so the deno CLI can move to deno_graph 0.110.0 for the config-imports feature
(denoland/deno#35320).